### PR TITLE
Shared base template + Marigold theme (midcentury visual refresh)

### DIFF
--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -1,0 +1,224 @@
+/* ==========================================================================
+   LTL Tutor — theme.css
+   A design-token layer + Bootstrap 4 restyle. Direction: midcentury / Bauhaus
+   ("Marigold"). Flat surfaces, real black doing structural work, near-square
+   corners, warm non-blue palette. Green/red are reserved for correctness only.
+
+   Loaded AFTER bootstrap.css and common.css so its overrides win. Colors are
+   driven by CSS custom properties so light and (OS) dark themes both work.
+   ========================================================================== */
+
+/* ---- Tokens: LIGHT ------------------------------------------------------- */
+:root {
+  --paper:      #eae0cc;   /* warm oat ground */
+  --surface:    #f5eee0;   /* cards, panels */
+  --surface-2:  #e0d4bb;   /* sunken / muted */
+  --ink:        #211c14;   /* warm near-black — the structural workhorse */
+  --ink-2:      #544c3c;   /* secondary text */
+  --ink-3:      #867c66;   /* muted / captions */
+  --line:       #d6cab0;   /* hairline */
+  --line-2:     #bfb08e;   /* stronger hairline / control borders */
+
+  /* Marigold brand: mustard with black ink (the Bauhaus move) */
+  --brand:        #e0a41c;
+  --brand-strong: #a97a06;
+  --brand-ink:    #211c14;
+  --brand-soft:   #f6e6bd;
+  --brand-line:   #e4cb8b;
+  --accent:       #bf5327;   /* terracotta accent */
+  --accent-strong:#993f1b;
+
+  /* semantics — correctness / status only */
+  --ok:   #4d7a39;  --ok-soft:  #e0e9cf;
+  --bad:  #a62b22;  --bad-soft: #f0dac9;
+  --warn: #b5731a;  --warn-soft:#f6e7cd;
+  --focus:#0b6b62;                          /* teal focus ring (a11y affordance) */
+
+  --r-sm: 3px; --r: 4px; --r-lg: 6px; --r-pill: 999px;
+
+  --font-sans: "Helvetica Neue", Helvetica, Arial, "Segoe UI", Roboto, system-ui, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+}
+
+/* ---- Tokens: DARK (follows OS preference) -------------------------------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:#1a1611; --surface:#231e16; --surface-2:#2d2719;
+    --ink:#efe6d3; --ink-2:#c9bda2; --ink-3:#928769;
+    --line:#372f1f; --line-2:#4a4029;
+
+    --brand:#e6ad33; --brand-strong:#f3c765; --brand-ink:#201a10;
+    --brand-soft:#332815; --brand-line:#4d3d1c;
+    --accent:#d9713f; --accent-strong:#ee9166;
+
+    --ok:#8dbf63; --ok-soft:#232a18; --bad:#e58a6c; --bad-soft:#2f1c16;
+    --warn:#e0a437; --warn-soft:#322414; --focus:#5fd0c4;
+  }
+}
+
+/* ---- Base ---------------------------------------------------------------- */
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+h1, h2, h3, h4, h5, h6 { color: var(--ink); font-weight: 800; letter-spacing: -.01em; }
+a { color: var(--accent-strong); }
+a:hover { color: var(--accent); }
+.text-muted { color: var(--ink-3) !important; }
+code, pre, .mono, kbd { font-family: var(--font-mono); }
+
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+/* ---- Utility strip + navbar --------------------------------------------- */
+.bg-light { background-color: var(--surface) !important; }
+.border-bottom { border-color: var(--line) !important; }
+
+.navbar {
+  border-bottom: 1px solid var(--line);
+  padding-top: .6rem; padding-bottom: .6rem;
+}
+.navbar.bg-light { background-color: color-mix(in srgb, var(--paper) 90%, transparent) !important; }
+/* specificity matches Bootstrap's .navbar-light .navbar-brand so it wins in dark mode too */
+.navbar-light .navbar-brand, .navbar-brand {
+  font-weight: 800; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--ink); font-size: 1.02rem;
+}
+.navbar-light .navbar-brand:hover, .navbar-brand:hover { color: var(--ink); }
+/* Bauhaus mark (square / circle / triangle) — optional, used in navbar.html */
+.bauhaus-mark { display: inline-flex; align-items: center; gap: 5px; vertical-align: -2px; margin-right: 8px; }
+.bauhaus-mark i { display: block; width: 14px; height: 14px; }
+.bauhaus-mark .sq { background: var(--brand); }
+.bauhaus-mark .ci { background: var(--accent); border-radius: 50%; }
+.bauhaus-mark .tr { width: 0; height: 0;
+  border-left: 7px solid transparent; border-right: 7px solid transparent; border-bottom: 14px solid var(--ink); }
+
+.navbar-light .navbar-nav .nav-link {
+  color: var(--ink-2); font-weight: 600;
+  border-bottom: 3px solid transparent; margin: 0 2px; padding: .4rem .7rem;
+}
+.navbar-light .navbar-nav .nav-link:hover,
+.navbar-light .navbar-nav .nav-link:focus { color: var(--ink); border-bottom-color: var(--brand); }
+.navbar-toggler { border-color: var(--line-2); }
+
+.dropdown-menu {
+  background: var(--surface); border: 1.5px solid var(--line-2); border-radius: var(--r);
+  box-shadow: none; color: var(--ink);
+}
+.dropdown-item { color: var(--ink-2); }
+.dropdown-item:hover, .dropdown-item:focus { background: var(--surface-2); color: var(--ink); }
+.dropdown-divider { border-color: var(--line); }
+
+/* ---- Buttons: rectangular, flat, hard-offset on hover ------------------- */
+.btn {
+  font-weight: 700; letter-spacing: .01em; border-radius: var(--r);
+  border-width: 1.5px; transition: transform .1s ease, box-shadow .1s ease, background-color .1s ease;
+}
+.btn-lg { border-radius: var(--r); }
+.btn-primary {
+  background-color: var(--brand); border-color: var(--ink); color: var(--brand-ink);
+}
+.btn-primary:hover {
+  background-color: var(--brand); border-color: var(--ink); color: var(--brand-ink);
+  transform: translate(-1px,-1px); box-shadow: 3px 3px 0 var(--ink);
+}
+.btn-primary:active, .btn-primary:not(:disabled):not(.disabled):active {
+  background-color: var(--brand-strong); border-color: var(--ink); color: var(--brand-ink);
+  transform: translate(1px,1px); box-shadow: none;
+}
+.btn-primary:focus, .btn-primary.focus { box-shadow: 0 0 0 .2rem var(--brand-line); }
+.btn-primary:disabled, .btn-primary.disabled {
+  background-color: var(--surface-2); border-color: var(--line-2); color: var(--ink-3);
+}
+
+.btn-outline-secondary { color: var(--ink); border-color: var(--ink); }
+.btn-outline-secondary:hover { background: var(--surface-2); color: var(--ink); border-color: var(--ink); }
+.btn-outline-success { color: var(--ok); border-color: var(--ok); }
+.btn-outline-success:hover { background: var(--ok); color: #fff; border-color: var(--ok); }
+.btn-link { color: var(--accent-strong); font-weight: 600; }
+.btn-link:hover { color: var(--accent); }
+
+/* ---- Cards: flat, hard-edged, structural borders ------------------------ */
+.card {
+  background: var(--surface);
+  border: 1.5px solid var(--line-2);
+  border-radius: var(--r-lg);
+  box-shadow: none;
+}
+.card.shadow-sm, .card.shadow { box-shadow: none !important; }
+.card-header {
+  background: var(--surface);
+  border-bottom: 1.5px solid var(--line-2);
+  font-weight: 700;
+}
+/* colored card headers → tokenized, still flat */
+.card-header.bg-primary { background-color: var(--brand) !important; color: var(--brand-ink) !important; border-bottom-color: var(--ink) !important; }
+.card-header.bg-success { background-color: var(--ok) !important; color: #fff !important; }
+.card-header.bg-warning { background-color: var(--warn) !important; color: #fff !important; }
+.card.border-primary { border-color: var(--brand) !important; }
+.card.border-warning { border-color: var(--warn) !important; }
+.card.bg-light { background-color: var(--surface-2) !important; }
+
+/* ---- Badges -------------------------------------------------------------- */
+.badge { border-radius: var(--r-sm); font-weight: 700; padding: .35em .6em; }
+.badge-light { background: var(--surface-2); color: var(--ink-2); border: 1px solid var(--line-2); }
+.badge-info { background: var(--ink); color: var(--paper); }
+.badge-primary { background: var(--brand); color: var(--brand-ink); }
+.badge-secondary { background: var(--surface-2); color: var(--ink-2); border: 1px solid var(--line-2); }
+.badge-success { background: var(--ok); color: #fff; }
+.badge-danger { background: var(--bad); color: #fff; }
+
+/* ---- List groups --------------------------------------------------------- */
+.list-group-item {
+  background: var(--surface); border-color: var(--line); color: var(--ink);
+}
+.list-group-item-action:hover, .list-group-item-action:focus { background: var(--surface-2); color: var(--ink); }
+.list-group-item-success { background: var(--ok-soft); border-color: color-mix(in srgb, var(--ok) 40%, transparent); color: var(--ink); }
+
+/* ---- Forms --------------------------------------------------------------- */
+.form-control {
+  background: var(--surface); color: var(--ink);
+  border: 1.5px solid var(--line-2); border-radius: var(--r);
+}
+.form-control:focus {
+  background: var(--surface); color: var(--ink);
+  border-color: var(--brand); box-shadow: 0 0 0 .2rem var(--brand-line);
+}
+.form-control::placeholder { color: var(--ink-3); }
+.input-group > .form-control { border-right: 0; }
+
+/* ---- Code / formula blocks (highlight.js themed to tokens) -------------- */
+/* highlight.js default.min.css hardcodes a light code theme; retheme it so
+   formulas match the surface (and don't glow white in dark mode). */
+pre { background: transparent; color: var(--ink); }
+.hljs, pre code.hljs { background: var(--surface-2) !important; color: var(--ink); border-radius: var(--r-sm); }
+.hljs-keyword { color: var(--brand-strong); font-weight: 700; }  /* G F X U → operators */
+
+/* Nothing in this theme is blue: retire Bootstrap's primary-blue utility. */
+.text-primary { color: var(--accent-strong) !important; }
+
+/* ---- Alerts -------------------------------------------------------------- */
+.alert { border-radius: var(--r); border-width: 1.5px; }
+.alert-secondary { background: var(--surface-2); border-color: var(--line-2); color: var(--ink); }
+.alert-danger { background: var(--bad-soft); border-color: color-mix(in srgb, var(--bad) 45%, transparent); color: var(--ink); }
+.alert-warning { background: var(--warn-soft); border-color: color-mix(in srgb, var(--warn) 45%, transparent); color: var(--ink); }
+
+/* ---- Modals -------------------------------------------------------------- */
+.modal-content { background: var(--surface); color: var(--ink); border: 1.5px solid var(--ink); border-radius: var(--r-lg); }
+.modal-header, .modal-footer { border-color: var(--line); }
+
+/* ---- Dark-mode patches for hardcoded-light spots in common.css ---------- */
+@media (prefers-color-scheme: dark) {
+  .footer, .footer.bg-light { background-color: var(--paper) !important; }
+  .ltl-hint { background-color: var(--surface); border-color: var(--line-2); }
+  .ltl-formula { color: var(--brand-strong); background-color: var(--brand-soft); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn, .btn-primary { transition: none; }
+}

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -5,7 +5,8 @@
    corners, warm non-blue palette. Green/red are reserved for correctness only.
 
    Loaded AFTER bootstrap.css and common.css so its overrides win. Colors are
-   driven by CSS custom properties so light and (OS) dark themes both work.
+   driven by CSS custom properties; single light theme by design — the token
+   layer keeps adding a dark theme later a contained change.
    ========================================================================== */
 
 /* ---- Tokens: LIGHT ------------------------------------------------------- */
@@ -38,22 +39,6 @@
 
   --font-sans: "Helvetica Neue", Helvetica, Arial, "Segoe UI", Roboto, system-ui, sans-serif;
   --font-mono: "SF Mono", ui-monospace, "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
-}
-
-/* ---- Tokens: DARK (follows OS preference) -------------------------------- */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --paper:#1a1611; --surface:#231e16; --surface-2:#2d2719;
-    --ink:#efe6d3; --ink-2:#c9bda2; --ink-3:#928769;
-    --line:#372f1f; --line-2:#4a4029;
-
-    --brand:#e6ad33; --brand-strong:#f3c765; --brand-ink:#201a10;
-    --brand-soft:#332815; --brand-line:#4d3d1c;
-    --accent:#d9713f; --accent-strong:#ee9166;
-
-    --ok:#8dbf63; --ok-soft:#232a18; --bad:#e58a6c; --bad-soft:#2f1c16;
-    --warn:#e0a437; --warn-soft:#322414; --focus:#5fd0c4;
-  }
 }
 
 /* ---- Base ---------------------------------------------------------------- */
@@ -208,13 +193,6 @@ pre { background: transparent; color: var(--ink); }
 /* ---- Modals -------------------------------------------------------------- */
 .modal-content { background: var(--surface); color: var(--ink); border: 1.5px solid var(--ink); border-radius: var(--r-lg); }
 .modal-header, .modal-footer { border-color: var(--line); }
-
-/* ---- Dark-mode patches for hardcoded-light spots in common.css ---------- */
-@media (prefers-color-scheme: dark) {
-  .footer, .footer.bg-light { background-color: var(--paper) !important; }
-  .ltl-hint { background-color: var(--surface); border-color: var(--line-2); }
-  .ltl-formula { color: var(--brand-strong); background-color: var(--brand-soft); }
-}
 
 @media (prefers-reduced-motion: reduce) {
   .btn, .btn-primary { transition: none; }

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -10,14 +10,14 @@
 
 /* ---- Tokens: LIGHT ------------------------------------------------------- */
 :root {
-  --paper:      #eae0cc;   /* warm oat ground */
-  --surface:    #f5eee0;   /* cards, panels */
-  --surface-2:  #e0d4bb;   /* sunken / muted */
+  --paper:      #f3eee4;   /* warm off-white ground (ivory, not clinical) */
+  --surface:    #fbf8f2;   /* cards — bright warm white */
+  --surface-2:  #eae3d5;   /* sunken / muted warm panel */
   --ink:        #211c14;   /* warm near-black — the structural workhorse */
   --ink-2:      #544c3c;   /* secondary text */
-  --ink-3:      #867c66;   /* muted / captions */
-  --line:       #d6cab0;   /* hairline */
-  --line-2:     #bfb08e;   /* stronger hairline / control borders */
+  --ink-3:      #82775f;   /* muted / captions */
+  --line:       #e7e0d0;   /* hairline */
+  --line-2:     #d3cab4;   /* stronger hairline / control borders */
 
   /* Marigold brand: mustard with black ink (the Bauhaus move) */
   --brand:        #e0a41c;

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -90,13 +90,10 @@ code, pre, .mono, kbd { font-family: var(--font-mono); }
   color: var(--ink); font-size: 1.02rem;
 }
 .navbar-light .navbar-brand:hover, .navbar-brand:hover { color: var(--ink); }
-/* Bauhaus mark (square / circle / triangle) — optional, used in navbar.html */
-.bauhaus-mark { display: inline-flex; align-items: center; gap: 5px; vertical-align: -2px; margin-right: 8px; }
+/* Brand mark — a single mustard square, used in navbar.html */
+.bauhaus-mark { display: inline-flex; align-items: center; vertical-align: -2px; margin-right: 8px; }
 .bauhaus-mark i { display: block; width: 14px; height: 14px; }
 .bauhaus-mark .sq { background: var(--brand); }
-.bauhaus-mark .ci { background: var(--accent); border-radius: 50%; }
-.bauhaus-mark .tr { width: 0; height: 0;
-  border-left: 7px solid transparent; border-right: 7px solid transparent; border-bottom: 14px solid var(--ink); }
 
 .navbar-light .navbar-nav .nav-link {
   color: var(--ink-2); font-weight: 600;

--- a/src/static/favicon.svg
+++ b/src/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <style>@media (prefers-color-scheme: dark) { .sq { fill: #e6ad33; } }</style>
+  <rect class="sq" x="3" y="3" width="26" height="26" fill="#e0a41c"/>
+</svg>

--- a/src/templates/auth/login.html
+++ b/src/templates/auth/login.html
@@ -1,16 +1,12 @@
-<!DOCTYPE html>
-<html>
+{% extends 'base.html' %}
 
-<head>
-    <title>LTL Tutor: Login</title>
+{% block title %}LTL Tutor: Login{% endblock %}
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
+{% block navbar %}{% endblock %}
 
+{% block container_class %}container mt-5{% endblock %}
+
+{% block head %}
     <style>
     .highlight-section {
         border: 2px solid #007bff;
@@ -19,10 +15,9 @@
         transition: background 0.3s, box-shadow 0.3s;
     }
     </style>
-</head>
+{% endblock %}
 
-<body>
-    <div class="container mt-5">
+{% block content %}
         <div>
         <p class="text-center mt-2 mb-2">
             LTLTutor is built and maintained by the <a href="https://cs.brown.edu/research/plt/">PLT Group at
@@ -128,8 +123,4 @@
 
 
 
-    </div>
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/auth/signup.html
+++ b/src/templates/auth/signup.html
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>LTL Tutor: Signup</title>
+{% extends 'base.html' %}
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-</head>
-<body>
-    <div class="container">
+{% block title %}LTL Tutor: Signup{% endblock %}
+
+{% block navbar %}{% endblock %}
+
+{% block content %}
         <div class="row justify-content-center">
             <div class="col-md-6">
                 <h1 class="text-center mb-4">Signup</h1>
@@ -55,9 +49,9 @@
                 </p>
             </div>
         </div>
-    </div>
-    {% include 'footer.html' %}
+{% endblock %}
 
+{% block scripts %}
     <script>
     document.getElementById('signupForm').addEventListener('submit', function(e) {
         const pw = document.getElementById('password').value;
@@ -68,5 +62,4 @@
         }
     });
     </script>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/authorquestion.html
+++ b/src/templates/authorquestion.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
-<html>
+{% extends 'base.html' %}
 
-<head>
-    <title>LTL Tutor Authoring Aid</title>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+{% block title %}LTL Tutor Authoring Aid{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block head %}
     <script>
 
         function addDistractor() {
@@ -163,12 +163,10 @@
             observer.observe(targetNode, config);
         });
     </script>
-</head>
+{% endblock %}
 
-<body>
-    <div class="container">
+{% block content %}
         <div class="container mt-4">
-            {% include 'navbar.html' %}
             <h1>Author an Exercise</h1>
 
             <div class="form-group">
@@ -289,7 +287,4 @@
                 JSON</button>
             {% endif %}
         </div>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}LTL Tutor{% endblock %}</title>
+    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
+
+    <!-- Bootstrap 4 + jQuery + Popper (themed via theme.css). Shared by every page. -->
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
+
+    {# Page-specific <head> assets: Chart.js, highlight.js, Font Awesome, trace renderer, etc. #}
+    {% block head %}{% endblock %}
+
+    <!-- App styles: bootstrap, then common.css, then theme.css so the theme wins. -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}">
+</head>
+
+<body>
+    <div class="{% block container_class %}container{% endblock %}">
+        {% block navbar %}{% include 'navbar.html' %}{% endblock %}
+        {% block content %}{% endblock %}
+    </div>
+
+    {% block footer %}{% include 'footer.html' %}{% endblock %}
+
+    {# Page-specific end-of-body scripts. #}
+    {% block scripts %}{% endblock %}
+</body>
+
+</html>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}LTL Tutor{% endblock %}</title>
     <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='favicon.svg') }}">
 
     <!-- Bootstrap 4 + jQuery + Popper (themed via theme.css). Shared by every page. -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>

--- a/src/templates/courseresponses.html
+++ b/src/templates/courseresponses.html
@@ -1,30 +1,21 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{course_name}} Responses</title>
+{% extends 'base.html' %}
+
+{% block title %}{{course_name}} Responses{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block head %}
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
         <script
         src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.1.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-    
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
 
 <!-- TODO: It would be nice to allow tables to be toggled. -->
 
-    <div class="container">
-        {% include 'navbar.html' %}
-    </div>
     <div class="container mt-4">
         <p class="lead mt-3 mb-4">
             {{ course_name }} has had {{ responses|length }} responses from {{ user_counts|length }} students.
@@ -128,7 +119,9 @@
         </table>
       </div>
     </div>
+{% endblock %}
 
+{% block scripts %}
     <!-- Scripts -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
@@ -172,5 +165,4 @@
             });
         });
     </script>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/exercise.html
+++ b/src/templates/exercise.html
@@ -1,18 +1,9 @@
-<!DOCTYPE html>
-<html>
+{% extends 'base.html' %}
 
-<head>
-    <title>LTL Tutor</title>
+{% block container_class %}container-lg{% endblock %}
 
+{% block head %}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-
-    <!-- Include Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-
-    <!-- Include Bootstrap JS and jQuery -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
     <script src="{{ url_for('static', filename='js/tracerenderer.js') }}"></script>
     <script src="{{ url_for('static', filename='js/eulerdiagram.js') }}"></script>
@@ -21,21 +12,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="{{ url_for('static', filename='js/ltlhljs.js') }}"></script>
 
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
     <script src="{{ url_for('static', filename='js/checkanswers.js') }}"></script>
     <script>
         hljs.registerLanguage('ltl', ltlSyntaxDefs);
         hljs.highlightAll();
     </script>
+{% endblock %}
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-</head>
-
-<body>
-    <div class="container-lg">
-        {% include 'navbar.html' %}
-
+{% block content %}
         <div id="questions">
             {% for q in questions %}
             {%set qindex = loop.index %}
@@ -142,20 +126,13 @@
                         Answer</button>
                     <!-- TODO: Disable this, and then re-enable -->
                     <button class="btn btn-primary next" disabled>Next Question</button>
-                    
+
 
                 </div>
             </div>
             {% endfor %}
         </div>
 
-        <script>
-            function enableNextButton(checkAnswerButton) {
-                var parent = checkAnswerButton.parentNode;
-                var nextButton = parent.getElementsByClassName('next')[0];
-                nextButton.disabled = false;
-            }
-        </script>
         <div id="feedback">
 
         </div>
@@ -184,8 +161,16 @@
                 </div>
             </div>
         </div>
-    </div>
+{% endblock %}
 
+{% block scripts %}
+    <script>
+        function enableNextButton(checkAnswerButton) {
+            var parent = checkAnswerButton.parentNode;
+            var nextButton = parent.getElementsByClassName('next')[0];
+            nextButton.disabled = false;
+        }
+    </script>
 
     <script>
         $(document).ready(function () {
@@ -266,8 +251,4 @@
             });
         });
     </script>
-
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/exercise_closed.html
+++ b/src/templates/exercise_closed.html
@@ -1,15 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ title or 'Exercise unavailable' }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-</head>
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% extends 'base.html' %}
+
+{% block title %}{{ title or 'Exercise unavailable' }}{% endblock %}
+
+{% block container_class %}container mt-4{% endblock %}
+
+{% block content %}
 
         <div class="alert alert-warning mt-4" role="alert">
             <h4 class="alert-heading">{{ title or 'Exercise unavailable' }}</h4>
@@ -21,8 +16,4 @@
         </div>
 
         <a href="/" class="btn btn-primary">Return to dashboard</a>
-    </div>
-
-    {% include 'footer.html' %}
-</body>
-</html>
+{% endblock %}

--- a/src/templates/exercise_syntax_picker.html
+++ b/src/templates/exercise_syntax_picker.html
@@ -1,21 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor: Choose Syntax</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-</head>
+{% block title %}LTL Tutor: Choose Syntax{% endblock %}
 
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% block container_class %}container mt-4{% endblock %}
+
+{% block content %}
 
         <div class="card mt-4 shadow-sm">
             <div class="card-body text-center">
@@ -34,9 +23,4 @@
                 </div>
             </div>
         </div>
-    </div>
-
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/exercisehome.html
+++ b/src/templates/exercisehome.html
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor: Exercise Home</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-</head>
+{% block title %}LTL Tutor: Exercise Home{% endblock %}
 
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% block container_class %}container mt-4{% endblock %}
+
+{% block content %}
 
         <div class="container mt-4">
             <div class="jumbotron text-center">
@@ -42,8 +32,4 @@
                 }
             </script>
         </div>
-    </div>
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,149 +1,128 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor</title>
-    <script
-        src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.1.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+{% block head %}
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.1.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-    
-</head>
+{% endblock %}
 
-<body>
+{% block content %}
     <!-- The number of misconceptions needed before review -->
     {% set threshold = 5 %}
 
-    <div class="container">
-        {% include 'navbar.html' %}
-
-        <div class="d-flex justify-content-between align-items-center mt-3 mb-3 flex-wrap">
-            <div class="d-flex align-items-center">
-                {% if num_logs > 0 %}
-                <span class="badge badge-light p-2 mr-2" style="font-size: 0.9em;">
-                    {{ num_correct }}/{{ num_logs }} correct <small class="text-muted">(30 days)</small>
-                </span>
-                {% endif %}
-                {% if user_course %}
-                <span class="badge badge-info p-2">{{ user_course }}</span>
-                {% endif %}
-            </div>
+    <div class="d-flex justify-content-between align-items-center mt-3 mb-3 flex-wrap">
+        <div class="d-flex align-items-center">
+            {% if num_logs > 0 %}
+            <span class="badge badge-light p-2 mr-2" style="font-size: 0.9em;">
+                {{ num_correct }}/{{ num_logs }} correct <small class="text-muted">(30 days)</small>
+            </span>
+            {% endif %}
+            {% if user_course %}
+            <span class="badge badge-info p-2">{{ user_course }}</span>
+            {% endif %}
         </div>
-
-        <!-- Course Exercises Section -->
-        {% if course_exercises and course_exercises|length > 0 %}
-        <div class="card border-primary mb-4">
-            <div class="card-header bg-primary text-white">
-                <h5 class="mb-0">Exercises for {{ user_course }}</h5>
-            </div>
-            <div class="card-body">
-                <p class="text-muted">Your instructor has assigned the following exercises:</p>
-                <div class="list-group">
-                    {% for exercise in course_exercises %}
-                    {% set is_completed = exercise.name in completed_exercises %}
-                    {% set is_expired = exercise.is_expired %}
-                    {% set allow_multiple = exercise.allow_multiple_submissions %}
-                    {% set href_target = '#' if is_expired else url_for('exercise_predefined_get') + '?sourceuri=instructor:' + exercise.id|string %}
-                    <a href="{{ href_target }}"
-                       class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {% if is_completed %}list-group-item-success{% endif %} {% if is_expired %}disabled text-muted{% endif %}"
-                       {% if is_expired %}aria-disabled="true"{% endif %}>
-                        <div>
-                            <strong>{{ exercise.name }}</strong>
-                            {% set questions = exercise.exercise_json | fromjson if exercise.exercise_json else [] %}
-                            <small class="text-muted ml-2">({{ questions|length }} questions)</small>
-                            {% if is_completed %}
-                            <span class="badge badge-success ml-2">✓ Completed</span>
-                            {% endif %}
-                            {% if is_expired %}
-                            <span class="badge badge-danger ml-2">Closed</span>
-                            {% endif %}
-                            {% if not allow_multiple %}
-                            <span class="badge badge-info ml-2">Single submission</span>
-                            {% endif %}
-                        </div>
-                        <span class="badge badge-{% if is_completed %}secondary{% else %}primary{% endif %} badge-pill">
-                            {% if is_completed %}Retake →{% else %}Start →{% endif %}
-                        </span>
-                    </a>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-        {% endif %}
-
-        {% if misconception_count is defined and misconception_count > threshold %}
-        <div class="card border-warning mb-4">
-            <!-- <div class="card-header bg-warning">
-                <h5 class="mb-0">Recommended Review</h5>
-            </div> -->
-            <div class="card-body">
-                {% include max_misconception %}
-            </div>
-        </div>
-        {% endif %}
-
-        <!-- Main Action Card -->
-        <div class="card shadow-sm mb-4">
-            <div class="card-body text-center py-5">
-                <a href="/exercise/generate" class="btn btn-lg btn-primary px-5">
-                    Begin Personalized Exercise
-                </a>
-                <p class="text-muted mb-4">
-                    Exercises adapt in complexity and topic based on your previous responses.<br>
-                    As you improve, exercises become more challenging and focus on areas where you need practice.
-                </p>
-
-            </div>
-        </div>
-
-        <!-- Getting Started Card (for new users) -->
-        {% if misconception_count is not defined or misconception_count < threshold %}
-        <div class="card bg-light mb-4">
-            <div class="card-body">
-                <h5 class="card-title">New to LTL Tutor?</h5>
-                <p class="card-text mb-2">
-                    Make sure you're familiar with one of the <a href="/ltl">LTL syntaxes</a> supported by this tool,
-                    then start with a personalized exercise above.
-                </p>
-                <small class="text-muted">
-                    <em>Areas for review will appear after you complete a few exercises.</em>
-                </small>
-            </div>
-        </div>
-        {% endif %}
-
-        <!-- Load Specific Exercise -->
-        <div class="card mb-4">
-            <div class="card-body">
-                <h6 class="text-muted mb-3">Have an exercise code?</h6>
-                <div class="input-group">
-                    <input type="text" class="form-control" id="exerciseIdInput" placeholder="Enter exercise name...">
-                    <div class="input-group-append">
-                        <button class="btn btn-outline-secondary" type="button" onclick="loadExercise()">Load Exercise</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <script>
-            function loadExercise() {
-                var exerciseId = document.getElementById('exerciseIdInput').value;
-                window.location.href = '/exercise/load/' + exerciseId;
-            }
-        </script>
-
-
     </div>
-    {% include 'footer.html' %}
 
-</body>
+    <!-- Course Exercises Section -->
+    {% if course_exercises and course_exercises|length > 0 %}
+    <div class="card border-primary mb-4">
+        <div class="card-header bg-primary text-white">
+            <h5 class="mb-0">Exercises for {{ user_course }}</h5>
+        </div>
+        <div class="card-body">
+            <p class="text-muted">Your instructor has assigned the following exercises:</p>
+            <div class="list-group">
+                {% for exercise in course_exercises %}
+                {% set is_completed = exercise.name in completed_exercises %}
+                {% set is_expired = exercise.is_expired %}
+                {% set allow_multiple = exercise.allow_multiple_submissions %}
+                {% set href_target = '#' if is_expired else url_for('exercise_predefined_get') + '?sourceuri=instructor:' + exercise.id|string %}
+                <a href="{{ href_target }}"
+                   class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {% if is_completed %}list-group-item-success{% endif %} {% if is_expired %}disabled text-muted{% endif %}"
+                   {% if is_expired %}aria-disabled="true"{% endif %}>
+                    <div>
+                        <strong>{{ exercise.name }}</strong>
+                        {% set questions = exercise.exercise_json | fromjson if exercise.exercise_json else [] %}
+                        <small class="text-muted ml-2">({{ questions|length }} questions)</small>
+                        {% if is_completed %}
+                        <span class="badge badge-success ml-2">✓ Completed</span>
+                        {% endif %}
+                        {% if is_expired %}
+                        <span class="badge badge-danger ml-2">Closed</span>
+                        {% endif %}
+                        {% if not allow_multiple %}
+                        <span class="badge badge-info ml-2">Single submission</span>
+                        {% endif %}
+                    </div>
+                    <span class="badge badge-{% if is_completed %}secondary{% else %}primary{% endif %} badge-pill">
+                        {% if is_completed %}Retake →{% else %}Start →{% endif %}
+                    </span>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
-</html>
+    {% if misconception_count is defined and misconception_count > threshold %}
+    <div class="card border-warning mb-4">
+        <!-- <div class="card-header bg-warning">
+            <h5 class="mb-0">Recommended Review</h5>
+        </div> -->
+        <div class="card-body">
+            {% include max_misconception %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Main Action Card -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-body text-center py-5">
+            <a href="/exercise/generate" class="btn btn-lg btn-primary px-5">
+                Begin Personalized Exercise
+            </a>
+            <p class="text-muted mb-4">
+                Exercises adapt in complexity and topic based on your previous responses.<br>
+                As you improve, exercises become more challenging and focus on areas where you need practice.
+            </p>
+
+        </div>
+    </div>
+
+    <!-- Getting Started Card (for new users) -->
+    {% if misconception_count is not defined or misconception_count < threshold %}
+    <div class="card bg-light mb-4">
+        <div class="card-body">
+            <h5 class="card-title">New to LTL Tutor?</h5>
+            <p class="card-text mb-2">
+                Make sure you're familiar with one of the <a href="/ltl">LTL syntaxes</a> supported by this tool,
+                then start with a personalized exercise above.
+            </p>
+            <small class="text-muted">
+                <em>Areas for review will appear after you complete a few exercises.</em>
+            </small>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Load Specific Exercise -->
+    <div class="card mb-4">
+        <div class="card-body">
+            <h6 class="text-muted mb-3">Have an exercise code?</h6>
+            <div class="input-group">
+                <input type="text" class="form-control" id="exerciseIdInput" placeholder="Enter exercise name...">
+                <div class="input-group-append">
+                    <button class="btn btn-outline-secondary" type="button" onclick="loadExercise()">Load Exercise</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    function loadExercise() {
+        var exerciseId = document.getElementById('exerciseIdInput').value;
+        window.location.href = '/exercise/load/' + exerciseId;
+    }
+</script>
+{% endblock %}

--- a/src/templates/instructor/exercise_builder.html
+++ b/src/templates/instructor/exercise_builder.html
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor: {{ 'Edit' if exercise else 'Create' }} Exercise</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
+{% block title %}LTL Tutor: {{ 'Edit' if exercise else 'Create' }} Exercise{% endblock %}
+
+{% block container_class %}container mt-4{% endblock %}
+
+{% block head %}
     <style>
         .question-card {
             border-left: 4px solid #007bff;
@@ -71,11 +65,9 @@
             min-height: 1.3rem;
         }
     </style>
-</head>
+{% endblock %}
 
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% block content %}
 
         <div class="d-flex justify-content-between align-items-center mb-4">
             <div>
@@ -122,7 +114,7 @@
                                 <select class="form-control" id="course" name="course">
                                     <option value="">-- Not assigned --</option>
                                     {% for course_name in course_names %}
-                                    <option value="{{ course_name }}" 
+                                    <option value="{{ course_name }}"
                                             {{ 'selected' if exercise and exercise.course == course_name else '' }}>
                                         {{ course_name }}
                                     </option>
@@ -195,7 +187,7 @@
 
                     <input type="hidden" id="exercise_json" name="exercise_json"
                            value="{{ exercise.exercise_json | tojson | safe if exercise and exercise.exercise_json else '[]' }}">
-                    
+
                     <div class="btn-group btn-block mb-3">
                         <button type="submit" id="saveExerciseBtn" class="btn btn-success">
                             {{ 'Update' if exercise else 'Create' }} Exercise
@@ -372,10 +364,9 @@
                 </div>
             </div>
         </form>
-    </div>
+{% endblock %}
 
-    {% include 'footer.html' %}
-
+{% block scripts %}
     <script>
     // State
     let questions = [];
@@ -1263,6 +1254,4 @@
             .replace(/\r/g, '\\r');
     }
     </script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/instructor/exercises.html
+++ b/src/templates/instructor/exercises.html
@@ -1,21 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor: My Exercises</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-</head>
+{% block title %}LTL Tutor: My Exercises{% endblock %}
 
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% block container_class %}container mt-4{% endblock %}
+
+{% block content %}
 
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1>My Exercises</h1>
@@ -94,15 +83,15 @@
                         </td>
                         <td>
                             <div class="btn-group btn-group-sm">
-                                <a href="{{ url_for('authroutes.edit_instructor_exercise', exercise_id=exercise.id) }}" 
+                                <a href="{{ url_for('authroutes.edit_instructor_exercise', exercise_id=exercise.id) }}"
                                    class="btn btn-outline-primary">Edit</a>
-                                <a href="{{ url_for('exercise_predefined_get') }}?sourceuri=instructor:{{ exercise.id }}" 
+                                <a href="{{ url_for('exercise_predefined_get') }}?sourceuri=instructor:{{ exercise.id }}"
                                    class="btn btn-outline-success" target="_blank">Preview</a>
                                 <button type="button" class="btn btn-outline-secondary copy-link-btn"
                                         data-link="{{ url_for('exercise_predefined_get', _external=True) }}?sourceuri=instructor:{{ exercise.id }}">
                                     Copy Link
                                 </button>
-                                <form action="{{ url_for('authroutes.delete_instructor_exercise', exercise_id=exercise.id) }}" 
+                                <form action="{{ url_for('authroutes.delete_instructor_exercise', exercise_id=exercise.id) }}"
                                       method="POST" style="display:inline;"
                                       onsubmit="return confirm('Are you sure you want to delete this exercise?');">
                                     <button type="submit" class="btn btn-outline-danger">Delete</button>
@@ -118,7 +107,7 @@
         <div class="alert alert-secondary">
             <p class="mb-0">You haven't created any exercises yet.</p>
             <p class="mb-0 mt-2">
-                <a href="{{ url_for('authroutes.create_instructor_exercise') }}">Create your first exercise</a> 
+                <a href="{{ url_for('authroutes.create_instructor_exercise') }}">Create your first exercise</a>
                 to get started!
             </p>
         </div>
@@ -132,27 +121,26 @@
             </div>
             <div class="card-body">
                 <p class="text-muted">
-                    When you assign an exercise to a course, students in that course will be able to access it 
+                    When you assign an exercise to a course, students in that course will be able to access it
                     directly from their dashboard.
                 </p>
                 {% if course_names and course_names|length > 0 %}
-                <p>Your courses: 
+                <p>Your courses:
                     {% for course in course_names %}
                     <span class="badge badge-primary">{{ course }}</span>
                     {% endfor %}
                 </p>
                 {% else %}
                 <p class="text-muted">
-                    You haven't registered any courses yet. 
+                    You haven't registered any courses yet.
                     <a href="{{ url_for('instructorhome') }}">Register a course</a> first.
                 </p>
                 {% endif %}
             </div>
         </div>
-    </div>
+{% endblock %}
 
-    {% include 'footer.html' %}
-    
+{% block scripts %}
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('.copy-link-btn').forEach(function(btn) {
@@ -167,6 +155,4 @@
         });
     });
     </script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/instructorhome.html
+++ b/src/templates/instructorhome.html
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor: Instructor Home</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-</head>
+{% block title %}LTL Tutor: Instructor Home{% endblock %}
 
-<body>
-    <div class="container mt-4">
-        {% include 'navbar.html' %}
+{% block container_class %}container mt-4{% endblock %}
+
+{% block content %}
 
 
         <div class="container mt-4 mb-2 justify-content-center">
@@ -35,7 +25,7 @@
                 {% if messages %}
                 <div class="card-footer">
                     <div>
-                        
+
                             {% for message in messages %}
                                     {{ message | safe}}
                                     <hr>
@@ -150,8 +140,9 @@
             </div>
         </div>
 
-    </div>
-    {% include 'footer.html' %}
+{% endblock %}
+
+{% block scripts %}
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('.copy-login-link-btn').forEach(function(btn) {
@@ -165,6 +156,4 @@
         });
     });
     </script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/loadfromjson.html
+++ b/src/templates/loadfromjson.html
@@ -1,23 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-</head>
+{% block footer %}{% endblock %}
 
-<body>
-
-    
-    <div class="container mt-4">
-
-        {% include 'navbar.html' %}
+{% block content %}
 
         <h5> Load an Exercise from JSON</h5>
         <form id="exerciseForm" action="/exercise/predefined" method="post">
@@ -43,7 +28,9 @@
                 </div>
             </div>
         </form>
-    </div>
+{% endblock %}
+
+{% block scripts %}
     <script>
         function changeAction() {
             var form = document.getElementById('exerciseForm');
@@ -51,8 +38,4 @@
             form.action = '/exercise/' + select.value;
         }
     </script>
-
-
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/ltl.html
+++ b/src/templates/ltl.html
@@ -1,23 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-</head>
-
-<body>
-    <div class="container">
-        {% include 'navbar.html' %}
-
+{% block content %}
 
 
 
@@ -126,14 +109,16 @@
                 </tbody>
             </table>
         </div>
-    </div>
+{% endblock %}
+
+{% block scripts %}
     <script>
         function setLtlSyntax(syntax) {
             document.cookie = "ltlsyntax=" + syntax + "; path=/";
-            
+
             updateSyntaxExamples(syntax);
         }
-    
+
         // Function to get the value of a cookie by name
         function getCookie(name) {
             let cookieArr = document.cookie.split(";");
@@ -145,7 +130,7 @@
             }
             return null;
         }
-    
+
         // Function to update the Until text based on the syntax
         function updateSyntaxExamples(syntax) {
 
@@ -186,7 +171,7 @@
                 eventuallyExample.innerText = 'EVENTUALLY a';
                 nextCode.innerText = 'NEXT_STATE';
                 nextExample.innerText = 'NEXT_STATE a';
-                
+
             } else if (syntax === 'Electrum') {
                 untilCode.innerText = 'UNTIL';
                 untilExample.innerText = 'a UNTIL b';
@@ -198,7 +183,7 @@
                 nextExample.innerText = 'AFTER a';
             }
         }
-    
+
         document.addEventListener('DOMContentLoaded', (event) => {
             let currentSyntax = getCookie('ltlsyntax');
             if (currentSyntax) {
@@ -208,7 +193,4 @@
             }
         });
     </script>
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/ltltoeng_rating.html
+++ b/src/templates/ltltoeng_rating.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
-<html>
+{% extends 'base.html' %}
 
-<head>
-    <title>Rate English Paraphrases</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+{% block title %}Rate English Paraphrases{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block container_class %}{% endblock %}
+
+{% block head %}
     <style>
         mark {
             padding: 0.2rem;
@@ -58,11 +58,9 @@
             color: #6c757d;
         }
     </style>
-</head>
+{% endblock %}
 
-<body>
-    {% include 'navbar.html' %}
-
+{% block content %}
     <div class="container my-4">
         <div class="d-flex align-items-center mb-3">
             <h3 class="mb-0">How Similar Are These English Sentences?</h3>
@@ -139,7 +137,9 @@
             </div>
         {% endif %}
     </div>
-</body>
+{% endblock %}
+
+{% block scripts %}
 <script>
     function toggleUnsure(isChecked) {
         const slider = document.getElementById('likertRange');
@@ -153,4 +153,4 @@
         }
     }
 </script>
-</html>
+{% endblock %}

--- a/src/templates/ltltoengui.html
+++ b/src/templates/ltltoengui.html
@@ -1,15 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL → English</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-</head>
-<body>
-    <div class="container">
-        {% include 'navbar.html' %}
+{% extends 'base.html' %}
+
+{% block title %}LTL → English{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block content %}
 
         <div class="card shadow-sm mt-4 mb-4">
             <div class="card-header bg-primary text-white">
@@ -94,8 +89,9 @@
                 {% endif %}
             </div>
         </div>
-    </div>
+{% endblock %}
 
+{% block scripts %}
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const form = document.getElementById('ltl-to-eng-feedback-form');
@@ -296,8 +292,4 @@
             }
         });
     </script>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/navbar.html
+++ b/src/templates/navbar.html
@@ -6,7 +6,7 @@
 <!-- Navbar -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
     <a class="navbar-brand" href="/">
-        <span class="bauhaus-mark" aria-hidden="true"><i class="sq"></i><i class="ci"></i><i class="tr"></i></span>Tutor Dashboard</a>
+        <span class="bauhaus-mark" aria-hidden="true"><i class="sq"></i></span>Tutor Dashboard</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/src/templates/navbar.html
+++ b/src/templates/navbar.html
@@ -5,7 +5,8 @@
 
 <!-- Navbar -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
-    <a class="navbar-brand" href="/">Tutor Dashboard</a>
+    <a class="navbar-brand" href="/">
+        <span class="bauhaus-mark" aria-hidden="true"><i class="sq"></i><i class="ci"></i><i class="tr"></i></span>Tutor Dashboard</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/src/templates/stepper.html
+++ b/src/templates/stepper.html
@@ -1,32 +1,19 @@
-<!DOCTYPE html>
-<html>
+{% extends 'base.html' %}
 
-<head>
-    <title>LTL Stepper</title>
+{% block title %}LTL Stepper{% endblock %}
 
-    <!-- Include Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-
-    <!-- Include Bootstrap JS and jQuery -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
+{% block head %}
     <script src="{{ url_for('static', filename='js/tracerenderer.js') }}"></script>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="{{ url_for('static', filename='js/ltlhljs.js') }}"></script>
 
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-
     <script>
         hljs.registerLanguage('ltl', ltlSyntaxDefs);
         hljs.highlightAll();
     </script>
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 
     <style>
@@ -244,12 +231,9 @@
             }
         }
     </style>
+{% endblock %}
 
-</head>
-
-<body>
-    <div class="container">
-        {% include 'navbar.html' %}
+{% block content %}
 
         <div id="Controls">
 
@@ -418,7 +402,7 @@
                 Each row represents a subformula, and each column represents a time step.
                 Values are shown as <strong class="matrix-satisfied">1</strong> (satisfied) or <strong class="matrix-unsatisfied">0</strong> (unsatisfied).
                 </p>
-                
+
                 {% if matrix_data.subformulae %}
                 <!-- Matrix view table -->
                 <table class="table table-bordered table-sm" id="matrixTable">
@@ -474,10 +458,17 @@
                 {% endif %}
             </div>
         </div>
-    </div>
 
     <hr>
 
+    <div class="container mt-4 mb-4">
+        <button type="button" class="btn btn-outline-secondary btn-block" data-toggle="modal" data-target="#exampleModal">
+            <p class="text-muted"> Step through a different trace &bsol; formula pair </p>
+        </button>
+    </div>
+{% endblock %}
+
+{% block scripts %}
     <script>
         $(document).ready(function () {
 
@@ -651,14 +642,4 @@
             });
         });
     </script>
-
-    <div class="container mt-4 mb-4">
-        <button type="button" class="btn btn-outline-secondary btn-block" data-toggle="modal" data-target="#exampleModal">
-            <p class="text-muted"> Step through a different trace &bsol; formula pair </p>
-        </button>
-    </div>
-
-    {% include 'footer.html' %}
-</body>
-
-</html>
+{% endblock %}

--- a/src/templates/student/profile.html
+++ b/src/templates/student/profile.html
@@ -1,36 +1,20 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends 'base.html' %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LTL Tutor</title>
+{% block footer %}{% endblock %}
 
+{% block head %}
     <!-- Include Chart.js (already present) -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@2.2.2"></script>
+{% endblock %}
 
-
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <script src="{{ url_for('static', filename='js/common-functionality.js') }}"></script>
-    <meta name="description" content="Learn Linear Temporal Logic (LTL) with this interactive tutor.">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
-
-</head>
-
-<body>
-
-    <div class="container">
-        {% include 'navbar.html' %}
+{% block content %}
 
 
         <div class="mt-4 mb-4">
             <h1 class="text-center">Your Profile</h1>
             <p class="text-center">
-            In the last {{lookback_days}} days, you have 
+            In the last {{lookback_days}} days, you have
             answered <span class="font-weight-bolder"> {{num_correct}} out of {{num_answered}} </span> question(s) correctly.
             </p>
         </div>
@@ -88,8 +72,8 @@
 
         <h3 class="mt-5">Estimated Misconceptions Over Time</h3>
         <p class="text-muted">
-            This chart shows how your misconception likelihood has evolved over time using 
-            <a href="https://doi.org/10.1007/BF01099821" target="_blank" rel="noopener noreferrer" aria-label="Read about Bayesian Knowledge Tracing research paper">Bayesian Knowledge Tracing</a> 
+            This chart shows how your misconception likelihood has evolved over time using
+            <a href="https://doi.org/10.1007/BF01099821" target="_blank" rel="noopener noreferrer" aria-label="Read about Bayesian Knowledge Tracing research paper">Bayesian Knowledge Tracing</a>
             combined with spaced repetition principles.
         </p>
         <canvas id="allMisconceptionsChart"></canvas>
@@ -102,7 +86,7 @@
                 {% endfor %}
             };
 
-            
+
             // Find the latest timestamp to compute "days ago"
             let latestTimestamp = 0;
             for (const weights of Object.values(misconceptionData)) {
@@ -222,6 +206,4 @@
             });
         });
         </script>
-    </div>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/studentexercises.html
+++ b/src/templates/studentexercises.html
@@ -1,14 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Generated Exercises</title>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
+{% extends 'base.html' %}
+
+{% block title %}Generated Exercises{% endblock %}
+
+{% block container_class %}container py-3{% endblock %}
+
+{% block head %}
     <style>
         .controls-card {
             border: 1px solid #d9e2ec;
@@ -109,10 +105,9 @@
             }
         }
     </style>
-</head>
-<body>
-    <div class="container py-3">
-        {% include 'navbar.html' %}
+{% endblock %}
+
+{% block content %}
 
         <div class="d-flex justify-content-between align-items-start flex-wrap mt-3 mb-3">
             <div>
@@ -325,10 +320,9 @@
         {% endif %}
 
         <div id="noResults" class="alert alert-light d-none">No exercises match the current filters.</div>
-    </div>
+{% endblock %}
 
-    {% include 'footer.html' %}
-
+{% block scripts %}
     <script>
         (function () {
             const rawData = {{ raw_exercises|tojson }};
@@ -430,5 +424,4 @@
             renderCards();
         })();
     </script>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/studentlogs.html
+++ b/src/templates/studentlogs.html
@@ -1,13 +1,19 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Student Logs</title>
+{% extends 'base.html' %}
+
+{% block title %}Student Logs{% endblock %}
+
+{% block navbar %}{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block container_class %}{% endblock %}
+
+{% block head %}
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css">
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
     <h1>Your Logs</h1>
     <button id="downloadJsonBtn">Download As JSON</button>
     <table id="logsTable" class="display">
@@ -42,6 +48,9 @@
             {% endfor %}
         </tbody>
     </table>
+{% endblock %}
+
+{% block scripts %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
     <script>
@@ -62,5 +71,4 @@
             });
         });
     </script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## What & why

The UI read as stock **Bootstrap 4** — default blue/white, and every page hand-rolled its own `<head>` (35 duplicated skeletons, zero `{% extends %}`), which is why it drifted and felt un-fixable. This PR fixes the *foundation* and gives it a committed visual identity.

Two things:
1. **One shared shell** (`base.html`) so the `<head>`, nav, footer and asset loading live in a single place.
2. **A token-based theme** (`theme.css`) that restyles Bootstrap 4 into a warm, flat **midcentury / Bauhaus** look ("Marigold") — no framework added, no build step.

## Changes

- **`base.html`** (new) — shared shell with blocks: `title`, `head`, `container_class`, `navbar`, `content`, `footer`, `scripts`. Loads Bootstrap + jQuery, `common.css` and `theme.css` once.
- **`theme.css`** (new) — design tokens + Bootstrap 4 overrides for navbar, buttons, cards, badges, list-groups, forms, alerts, modals, and highlight.js formula blocks. Warm **off-white/ivory** ground · plum-black ink · **mustard** brand (black-ink buttons) · **terracotta** accent. **Green/red reserved strictly for correctness.** Single light theme (see note below).
- **`navbar.html`** — single mustard **square** brand mark.
- **`favicon.svg`** (new) — the same square, wired into `base.html` so it shows in the browser tab.
- **20 page templates** migrated to `{% extends 'base.html' %}`. Page-specific assets → `{% block head %}`; end-of-body scripts → `{% block scripts %}`.

## Design intent

Warm, non-blue, deliberately *not* rounded-everything: flat surfaces, real black doing structural work, near-square (4px) corners, bright ivory ground so it reads clean without being clinical. Builds on the existing accessible feedback work — visible focus rings, AA contrast, correctness never signalled by hue alone.

## On dark mode

Intentionally **light-only.** Dark mode doubles the contrast/QA surface for little benefit in a short-session teaching tool, and a half-tuned dark theme is an accessibility *regression*. The token layer stays in place, so a dark theme can be reintroduced later as a contained change if there's real demand.

## Verification

- All templates compile; each page's body content preserved across the 20 migrations.
- Rendered **home / exercise / login** and checked the graded-answer feedback states.
- Fixed along the way: a leftover `#007bff` link, container-width regressions on several pages, and the brand-mark / favicon.

## Reviewer notes

- **Bootstrap 4 retained** on purpose; a BS4→BS5 upgrade is a separate PR.
- `courseresponses` / `studentlogs` load full jQuery on top of base's slim jQuery (DataTables) — works, cleanup candidate.
- Frontend-verified only; a quick `./quickstart.sh` (Docker) smoke test of the live exercise flow is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)