### PR TITLE
Nav: instructor-only dashboard + global LTL-syntax setting in the top bar

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -282,14 +282,25 @@ def getUserId():
     return current_user.id
 
 
+# Endpoints that render an active exercise. The top-bar LTL-syntax setting is
+# locked on these pages so a student can't switch syntax mid-exercise (the
+# exercise was already rendered — and its answers logged — in one syntax).
+EXERCISE_ENDPOINTS = {'exercise', 'exercise_predefined_get', 'newexercise'}
+
+
 @app.context_processor
 def inject_nav_flags():
-    """Expose is_instructor to every template so the navbar can show instructor-only links."""
+    """Expose nav flags to every template: is_instructor (show instructor-only
+    links) and in_exercise (lock the top-bar LTL-syntax setting)."""
     try:
         is_instructor = current_user.is_authenticated and isinstance(current_user, CourseInstructor)
     except Exception:
         is_instructor = False
-    return {'is_instructor': is_instructor}
+    try:
+        in_exercise = request.endpoint in EXERCISE_ENDPOINTS
+    except Exception:
+        in_exercise = False
+    return {'is_instructor': is_instructor, 'in_exercise': in_exercise}
 
 
 @app.template_filter('flatten')

--- a/src/app.py
+++ b/src/app.py
@@ -29,6 +29,7 @@ from authroutes import (
     retrieve_course_data,
     get_owned_courses,
     login_required_as_courseinstructor,
+    CourseInstructor,
     getUserCourse,
     get_course_students,
     get_exercises_for_course,
@@ -280,7 +281,16 @@ def getUserName():
 def getUserId():
     return current_user.id
 
-    
+
+@app.context_processor
+def inject_nav_flags():
+    """Expose is_instructor to every template so the navbar can show instructor-only links."""
+    try:
+        is_instructor = current_user.is_authenticated and isinstance(current_user, CourseInstructor)
+    except Exception:
+        is_instructor = False
+    return {'is_instructor': is_instructor}
+
 
 @app.template_filter('flatten')
 def flatten(lst):

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -69,7 +69,7 @@ code, pre, .mono, kbd { font-family: var(--font-mono); }
   padding-top: .6rem; padding-bottom: .6rem;
 }
 .navbar.bg-light { background-color: color-mix(in srgb, var(--paper) 90%, transparent) !important; }
-/* specificity matches Bootstrap's .navbar-light .navbar-brand so it wins in dark mode too */
+/* lists .navbar-light .navbar-brand explicitly to out-specify Bootstrap's own rule */
 .navbar-light .navbar-brand, .navbar-brand {
   font-weight: 800; text-transform: uppercase; letter-spacing: .05em;
   color: var(--ink); font-size: 1.02rem;
@@ -175,8 +175,8 @@ code, pre, .mono, kbd { font-family: var(--font-mono); }
 .input-group > .form-control { border-right: 0; }
 
 /* ---- Code / formula blocks (highlight.js themed to tokens) -------------- */
-/* highlight.js default.min.css hardcodes a light code theme; retheme it so
-   formulas match the surface (and don't glow white in dark mode). */
+/* highlight.js default.min.css hardcodes its own code theme; retheme it so
+   formulas match the surface. */
 pre { background: transparent; color: var(--ink); }
 .hljs, pre code.hljs { background: var(--surface-2) !important; color: var(--ink); border-radius: var(--r-sm); }
 .hljs-keyword { color: var(--brand-strong); font-weight: 700; }  /* G F X U → operators */

--- a/src/templates/navbar.html
+++ b/src/templates/navbar.html
@@ -1,9 +1,12 @@
 <div class="d-flex justify-content-between align-items-center py-1 px-2 bg-light border-bottom small text-muted">
     <span>Version {% include 'version.html' %}</span>
     <div class="d-flex align-items-center">
-        <label for="topbarSyntaxSelect" class="mb-0 mr-2 text-muted">LTL syntax</label>
+        <label for="topbarSyntaxSelect" class="mb-0 mr-2 text-muted">
+            LTL syntax{% if in_exercise %} <span class="font-italic">(locked during exercise)</span>{% endif %}
+        </label>
         <select id="topbarSyntaxSelect" class="form-control form-control-sm d-inline-block mr-3"
-            style="width:auto;" aria-label="LTL syntax used across the tutor">
+            style="width:auto;"
+            {% if in_exercise %}disabled title="Finish or leave this exercise to change the LTL syntax"{% endif %}>
             <option value="Classic">Classic</option>
             <option value="Forge">Forge</option>
             <option value="Electrum">Electrum</option>
@@ -112,6 +115,9 @@
             var topSelect = document.getElementById('topbarSyntaxSelect');
             if (!topSelect) { return; }
             topSelect.value = current;
+
+            // Locked during an active exercise: show the current syntax, wire up nothing.
+            if (topSelect.disabled) { return; }
 
             // The /ltl reference page has its own in-page selector; keep the two in sync.
             var pageSelect = document.getElementById('ltlSyntaxSelect');

--- a/src/templates/navbar.html
+++ b/src/templates/navbar.html
@@ -1,6 +1,15 @@
 <div class="d-flex justify-content-between align-items-center py-1 px-2 bg-light border-bottom small text-muted">
     <span>Version {% include 'version.html' %}</span>
-    <span id="userid_field">{{uid}}</span>
+    <div class="d-flex align-items-center">
+        <label for="topbarSyntaxSelect" class="mb-0 mr-2 text-muted">LTL syntax</label>
+        <select id="topbarSyntaxSelect" class="form-control form-control-sm d-inline-block mr-3"
+            style="width:auto;" aria-label="LTL syntax used across the tutor">
+            <option value="Classic">Classic</option>
+            <option value="Forge">Forge</option>
+            <option value="Electrum">Electrum</option>
+        </select>
+        <span id="userid_field">{{uid}}</span>
+    </div>
 </div>
 
 <!-- Navbar -->
@@ -21,29 +30,18 @@
             </li>
 
 
-            <!-- Combined Dropdown for Generate Exercise and Syntax Choice -->
+            <!-- Syntax choice now lives in the top bar as a global setting. -->
             <li class="nav-item">
-                <a class="nav-link" href="/exercise/generate" >Generate Exercise</a>
+                <a class="nav-link" href="/exercise/generate">Generate Exercise</a>
             </li>
 
-
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle"  id="generateExerciseDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                   (<span id="currentLtlSyntax">Classic</span> syntax)
-                </a>
-                <div class="dropdown-menu" aria-labelledby="generateExerciseDropdown">
-                    <div class="dropdown-divider"></div>
-                    <a class="dropdown-item" href="/exercise/generate" onclick="setLtlSyntax('Classic')">Generate Exercise (Classic syntax)</a>
-                    <a class="dropdown-item" href="/exercise/generate" onclick="setLtlSyntax('Forge')">Generate Exercise (Forge syntax)</a>
-                    <a class="dropdown-item" href="/exercise/generate" onclick="setLtlSyntax('Electrum')">Generate Exercise (Electrum syntax)</a>
-                </div>
-            </li>
-
+            {% if is_instructor %}
             <li class="nav-item">
                 <a class="nav-link" href="/instructor/home" aria-expanded="false">
                     Instructor Dashboard
                 </a>
             </li>
+            {% endif %}
 
             {% if uid %}
             <li class="nav-item dropdown">
@@ -84,36 +82,57 @@
     </div>
 </nav>
 
-<!-- JavaScript to set the ltlsyntax cookie -->
+<!-- Global LTL-syntax setting (top bar). Persisted in the ltlsyntax cookie and read server-side. -->
 <script>
-    // Function to get the value of a cookie by name
-    function setLtlSyntax(syntax) {
-        document.cookie = "ltlsyntax=" + syntax + "; path=/";
-        document.getElementById('currentLtlSyntax').innerText = syntax;
-    }
+    (function () {
+        var SYNTAXES = ['Classic', 'Forge', 'Electrum'];
 
-    // Function to get the value of a cookie by name
-    function getCookie(name) {
-        let cookieArr = document.cookie.split(";");
-        for (let i = 0; i < cookieArr.length; i++) {
-            let cookiePair = cookieArr[i].split("=");
-            if (name == cookiePair[0].trim()) {
-                return decodeURIComponent(cookiePair[1]);
+        function getCookie(name) {
+            var cookieArr = document.cookie.split(";");
+            for (var i = 0; i < cookieArr.length; i++) {
+                var pair = cookieArr[i].split("=");
+                if (name === pair[0].trim()) {
+                    return decodeURIComponent(pair[1]);
+                }
             }
+            return null;
         }
-        return null;
-    }
 
-    // Set the initial value of the dropdown based on the cookie
-    document.addEventListener('DOMContentLoaded', (event) => {
-        let currentSyntax = getCookie('ltlsyntax');
-        if (currentSyntax) {
-            document.getElementById('currentLtlSyntax').innerText = currentSyntax;
+        function writeSyntaxCookie(syntax) {
+            document.cookie = "ltlsyntax=" + syntax + "; path=/";
         }
-        else {
-            setLtlSyntax('Classic');
-        }
-    });
+
+        document.addEventListener('DOMContentLoaded', function () {
+            var current = getCookie('ltlsyntax');
+            if (!current || SYNTAXES.indexOf(current) === -1) {
+                current = 'Classic';
+                writeSyntaxCookie(current);
+            }
+
+            var topSelect = document.getElementById('topbarSyntaxSelect');
+            if (!topSelect) { return; }
+            topSelect.value = current;
+
+            // The /ltl reference page has its own in-page selector; keep the two in sync.
+            var pageSelect = document.getElementById('ltlSyntaxSelect');
+
+            topSelect.addEventListener('change', function () {
+                writeSyntaxCookie(this.value);
+                if (pageSelect && pageSelect.value !== this.value) {
+                    pageSelect.value = this.value;
+                    pageSelect.dispatchEvent(new Event('change'));
+                }
+            });
+
+            if (pageSelect) {
+                pageSelect.addEventListener('change', function () {
+                    if (topSelect.value !== this.value) {
+                        topSelect.value = this.value;
+                    }
+                });
+            }
+        });
+    })();
     </script>
 
 <!-- Generic Modal -->


### PR DESCRIPTION
## Summary

Tidies up the top navigation, which was wrapping to two lines and conflating "change syntax" with "generate an exercise". Two changes:

**1. Instructor Dashboard is now instructor-only.** The link was shown to everyone even though `/instructor/home` is guarded by `login_required_as_courseinstructor` and just returns 403 for non-instructors. Added an `is_instructor` context processor (`isinstance(current_user, CourseInstructor)`) so the template's visibility matches the route's access control, and gated the link with `{% if is_instructor %}`.

**2. LTL syntax is now a system-wide setting in the top bar.** It used to be a `(Classic syntax)` dropdown in the nav whose items each *also* fired off `/exercise/generate` — so picking a syntax silently generated a new exercise. It's now a labelled `LTL syntax [ Classic ▾ ]` `<select>` in the top bar next to the version/username. Changing it only writes the `ltlsyntax` cookie (read server-side, unchanged) — no navigation, no exercise generated. "Generate Exercise" stays as its own link and uses whatever syntax is set.

The syntax JS is now an encapsulated IIFE (no global `setLtlSyntax`/`getCookie` leaking) and stays in sync with the `/ltl` reference page's own selector.

**3. The syntax setting is locked while an exercise is active.** An exercise is rendered — and its answers logged — in a single syntax, so switching syntax mid-exercise is misleading. A new `in_exercise` flag (true on the `exercise`, `exercise_predefined_get`, and `newexercise` endpoints) disables the top-bar `<select>` on those pages, shows a "(locked during exercise)" label, and short-circuits the JS so no cookie is written while locked. The stepper is treated as a separate tool and is **not** locked.

Also corrected two stale `theme.css` comments that referenced a dark mode the app no longer has (there was no functional dark-mode code left — no `prefers-color-scheme` block, no dark tokens, no toggle).

**Side benefit:** with the syntax dropdown gone and the instructor link hidden for students, the nav now fits on a single line.

## Verification

Rendered the real `navbar.html` with the real `theme.css` and drove it in a browser:

| Scenario | Instructor Dashboard | Syntax select | Log In/Out |
|---|---|---|---|
| Instructor | shown | top bar | Log Out |
| Student | hidden | top bar | Log Out |
| Logged out | hidden | top bar | Log In (Experiments also hidden) |

- Changing the top-bar select updates the `ltlsyntax` cookie to Forge/Electrum with **no navigation** — confirms it behaves as a setting, not an action.
- On an exercise page (`in_exercise=True`) the select renders `disabled`; an adversarial forced `value` + `change` leaves the cookie unchanged, while the same on a normal page still writes it.
- Reconstructed the `/ltl` page (real navbar + real `ltl.html`): each element id appears exactly once (no collision), both selectors sync two-way, examples update, **zero JS errors**.
- The select is named by its associated `<label for>` (which also carries the "locked during exercise" state) and uses native keyboard behaviour.

## Notes

- **Version intentionally stays 2.0.1** — these fall under the existing 2.0.1 release; no version bump.
- Scoped to `src/app.py`, `src/templates/navbar.html`, and `src/static/css/theme.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
