### PR TITLE
Add QR sign-up codes and persistent student accounts; require passwords (except Quick Start)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ psycopg2-binary
 flask-login
 inflect
 wordfreq>=3.0
+segno>=1.5

--- a/src/app.py
+++ b/src/app.py
@@ -30,6 +30,7 @@ from authroutes import (
     get_owned_courses,
     login_required_as_courseinstructor,
     CourseInstructor,
+    CourseStudent,
     getUserCourse,
     get_course_students,
     get_exercises_for_course,
@@ -389,6 +390,8 @@ def index():
     course_exercises = []
     completed_exercises = set()
     user_course = getUserCourse(userId)
+    # A student account with no course can join one from the home page.
+    can_join_course = isinstance(current_user, CourseStudent) and not user_course
     if user_course:
         course_exercises = get_exercises_for_course(user_course)
 
@@ -414,6 +417,7 @@ def index():
         num_logs=num_logs,
         num_correct=num_correct,
         user_course=user_course,
+        can_join_course=can_join_course,
         course_exercises=course_exercises,
         completed_exercises=completed_exercises
     )

--- a/src/authroutes.py
+++ b/src/authroutes.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, flash, current_app
+from flask import Flask, render_template, request, redirect, url_for, flash, current_app, Response
 from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.orm import Session, sessionmaker, Mapped, mapped_column
@@ -65,11 +65,23 @@ class User(UserMixin, Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(String, unique=True)
     type: Mapped[str] = mapped_column(String)
+    # Optional credential. Only account types that authenticate with a password
+    # (instructors and self-study students) populate this; anonymous and
+    # course-code students leave it NULL.
+    password_hash: Mapped[str] = mapped_column(String, nullable=True)
 
     __mapper_args__ = {
         'polymorphic_identity': 'user',
         'polymorphic_on': type
     }
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        if not self.password_hash:
+            return False
+        return check_password_hash(self.password_hash, password)
 
 
 class AnonymousStudent(User):
@@ -83,20 +95,22 @@ class CourseStudent(User):
         'polymorphic_identity': 'course-student',
     }
 
-    course_id: Mapped[str] = mapped_column(String, nullable=True) 
+    course_id: Mapped[str] = mapped_column(String, nullable=True)
+
+
+class SelfStudyStudent(User):
+    """A self-directed learner with a persistent, password-protected account and
+    no course. Lets a student keep their progress across devices and browsers
+    without needing an instructor or a course code."""
+    __mapper_args__ = {
+        'polymorphic_identity': 'self-study-student',
+    }
 
 
 class CourseInstructor(User):
     __mapper_args__ = {
         'polymorphic_identity': 'course-instructor',
     }
-    password_hash: Mapped[str] = mapped_column(String, nullable=True)
-
-    def set_password(self, password):
-        self.password_hash = generate_password_hash(password)
-
-    def check_password(self, password):
-        return check_password_hash(self.password_hash, password)
 
 
 def login_required_as_courseinstructor(f):
@@ -219,6 +233,17 @@ def login():
                     flash('Invalid username or password.')
                     return redirect(url_for('authroutes.login'))
 
+            elif user_type == 'self-study-student':
+                username = request.form.get('username')
+                password = request.form.get('password')
+                user = session.query(SelfStudyStudent).filter_by(username=username).first()
+
+                canLogin = (user is not None) and user.check_password(password)
+
+                if not canLogin:
+                    flash('Invalid username or password.')
+                    return redirect(url_for('authroutes.login'))
+
             elif user_type == 'course-student':
                 username = request.form.get('username')
                 course_id = request.form.get('course_id')
@@ -317,6 +342,38 @@ def signup():
     return render_template('auth/signup.html')
 
 
+@authroutes.route('/signup-student', methods=['GET', 'POST'])
+def signup_student():
+    """Create a self-study student account: a persistent, password-protected
+    account for a learner who is not part of a course."""
+    if request.method == 'POST':
+        with Session() as session:
+            username = request.form.get('username')
+            password = request.form.get('password')
+            confirm_password = request.form.get('confirm_password')
+
+            if not username or not password:
+                flash('Username and password are required.')
+                return render_template('auth/signup_student.html')
+
+            if password != confirm_password:
+                flash('Passwords do not match. Please try again.')
+                return render_template('auth/signup_student.html')
+
+            existing_user = session.query(User).filter_by(username=username).first()
+            if existing_user:
+                flash(f'Username {username} is already taken. Please choose another one.')
+                return render_template('auth/signup_student.html')
+
+            user = SelfStudyStudent(username=username)
+            user.set_password(password)
+            session.add(user)
+            session.commit()
+            login_user(user)
+            return redirect(url_for('index'))
+    return render_template('auth/signup_student.html')
+
+
 
 
 @authroutes.route('/register-course', methods=['GET', 'POST'])
@@ -345,9 +402,35 @@ def register_exercise():
 
             login_link = url_for('authroutes.login', user_type='course-student', course_id=course.name, _external=True)
 
-            flash(f'Course <code>{coursename}</code> registered successfully. <br><br> You can share it with students via the course code <code>{course.name}</code> or the link <code>{login_link}</code> <br><br>This link will also be available in your instructor dashboard.')
+            flash(f'Course <code>{coursename}</code> registered successfully. <br><br> You can share it with students via the course code <code>{course.name}</code> or the link <code>{login_link}</code> <br><br>This link, along with a scannable QR code, will also be available in your instructor dashboard.')
             return redirect(url_for('authroutes.register_exercise'))
     return render_template('instructorhome.html')
+
+
+@authroutes.route('/course/<course_name>/qr.svg')
+@login_required_as_courseinstructor
+def course_login_qr(course_name):
+    """Serve a QR code (SVG) encoding the student login link for a course.
+    Restricted to the instructor who owns the course. Students scan it to open
+    the pre-filled course sign-up/login page."""
+    import io
+    import segno
+
+    with Session() as session:
+        course = session.query(Course).filter_by(name=course_name).first()
+        if course is None or course.owner != current_user.username:
+            abort(404)
+
+    login_link = url_for(
+        'authroutes.login',
+        user_type='course-student',
+        course_id=course_name,
+        _external=True,
+    )
+    qr = segno.make(login_link, error='m')
+    buf = io.BytesIO()
+    qr.save(buf, kind='svg', scale=6, border=2)
+    return Response(buf.getvalue(), mimetype='image/svg+xml')
 
 
 def retrieve_course_data(course_name) -> Course:

--- a/src/authroutes.py
+++ b/src/authroutes.py
@@ -65,9 +65,9 @@ class User(UserMixin, Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(String, unique=True)
     type: Mapped[str] = mapped_column(String)
-    # Optional credential. Only account types that authenticate with a password
-    # (instructors and self-study students) populate this; anonymous and
-    # course-code students leave it NULL.
+    # Optional credential. Populated for accounts that authenticate with a
+    # password (instructors, and persistent student accounts); anonymous
+    # students and quick course-code students leave it NULL.
     password_hash: Mapped[str] = mapped_column(String, nullable=True)
 
     __mapper_args__ = {
@@ -91,20 +91,24 @@ class AnonymousStudent(User):
 
 
 class CourseStudent(User):
+    """A student account, identified by its (globally unique) username. The two
+    fields below are optional and independent:
+
+      * course_id     — set when the student is enrolled in a course (via a
+                        course code at login/signup, or by joining one later).
+      * password_hash — (inherited from User) set for a persistent account the
+                        student can log back into from any device. A course-code
+                        student with no password is quick to create but is bound
+                        to the browser/device it was created in.
+
+    So the same type covers a quick passwordless course-code student, a
+    persistent password-protected student, and any combination (e.g. a
+    persistent account that is also enrolled in a course)."""
     __mapper_args__ = {
         'polymorphic_identity': 'course-student',
     }
 
     course_id: Mapped[str] = mapped_column(String, nullable=True)
-
-
-class SelfStudyStudent(User):
-    """A self-directed learner with a persistent, password-protected account and
-    no course. Lets a student keep their progress across devices and browsers
-    without needing an instructor or a course code."""
-    __mapper_args__ = {
-        'polymorphic_identity': 'self-study-student',
-    }
 
 
 class CourseInstructor(User):
@@ -233,10 +237,11 @@ def login():
                     flash('Invalid username or password.')
                     return redirect(url_for('authroutes.login'))
 
-            elif user_type == 'self-study-student':
+            elif user_type == 'student-account':
+                ## Persistent student account: authenticate by password.
                 username = request.form.get('username')
                 password = request.form.get('password')
-                user = session.query(SelfStudyStudent).filter_by(username=username).first()
+                user = session.query(CourseStudent).filter_by(username=username).first()
 
                 canLogin = (user is not None) and user.check_password(password)
 
@@ -247,13 +252,6 @@ def login():
             elif user_type == 'course-student':
                 username = request.form.get('username')
                 course_id = request.form.get('course_id')
-                user = session.query(CourseStudent).filter_by(username=username, course_id=course_id).first()
-
-
-
-
-                ## TODO: User cannot be in more than one course. May have to change this later.
-
 
                 ## Ensure that course_id exists
                 course = session.query(Course).filter_by(name=course_id).first()
@@ -261,10 +259,20 @@ def login():
                     flash('Could not find a course with ID ' + course_id)
                     return redirect(url_for('authroutes.login'))
 
+                ## If this username belongs to a password-protected account, the
+                ## passwordless course-code path must not log in as them (that
+                ## would bypass their password). Send them to the Student account
+                ## login instead.
+                existing = session.query(CourseStudent).filter_by(username=username).first()
+                if existing is not None and existing.password_hash:
+                    flash('That username has a password. Please use the "Student account" login instead.')
+                    return redirect(url_for('authroutes.login'))
+
+                ## TODO: User cannot be in more than one course. May have to change this later.
+                user = session.query(CourseStudent).filter_by(username=username, course_id=course_id).first()
                 canLogin = user is not None
-                ## If user did not already exist, create a new user
+                ## If user did not already exist, create a new (passwordless) student enrolled in the course
                 if user is None:
-                    # Create a new user
                     user = CourseStudent(username=username, course_id=course_id)
                     try:
                         session.add(user)
@@ -274,8 +282,8 @@ def login():
                         flash('User {username} already exists.'.format(username=username))
                         session.rollback()
                         canLogin = False
-                        
-                
+
+
             elif user_type == 'anonymous-student':
                 ## This should really never happen, but just in case
                 tries_remaining = 10
@@ -344,13 +352,15 @@ def signup():
 
 @authroutes.route('/signup-student', methods=['GET', 'POST'])
 def signup_student():
-    """Create a self-study student account: a persistent, password-protected
-    account for a learner who is not part of a course."""
+    """Create a persistent, password-protected student account. Optionally
+    enroll in a course at the same time by supplying a course code; the student
+    can also join a course later from their home page."""
     if request.method == 'POST':
         with Session() as session:
             username = request.form.get('username')
             password = request.form.get('password')
             confirm_password = request.form.get('confirm_password')
+            course_code = (request.form.get('course_id') or '').strip()
 
             if not username or not password:
                 flash('Username and password are required.')
@@ -365,13 +375,45 @@ def signup_student():
                 flash(f'Username {username} is already taken. Please choose another one.')
                 return render_template('auth/signup_student.html')
 
-            user = SelfStudyStudent(username=username)
+            ## Optional enrollment: only accept a course code that exists.
+            course_id = None
+            if course_code:
+                course = session.query(Course).filter_by(name=course_code).first()
+                if course is None:
+                    flash('Could not find a course with ID ' + course_code)
+                    return render_template('auth/signup_student.html')
+                course_id = course_code
+
+            user = CourseStudent(username=username, course_id=course_id)
             user.set_password(password)
             session.add(user)
             session.commit()
             login_user(user)
             return redirect(url_for('index'))
     return render_template('auth/signup_student.html')
+
+
+@authroutes.route('/join-course', methods=['POST'])
+@login_required
+def join_course():
+    """Let a logged-in student enroll in a course by course code. Used by
+    persistent students who signed up without a course."""
+    if not isinstance(current_user, CourseStudent):
+        abort(403)
+
+    course_code = (request.form.get('course_id') or '').strip()
+    with Session() as session:
+        course = session.query(Course).filter_by(name=course_code).first()
+        if course is None:
+            flash('Could not find a course with ID ' + course_code)
+            return redirect(url_for('index'))
+
+        student = session.query(CourseStudent).filter_by(username=current_user.username).first()
+        if student is not None:
+            student.course_id = course_code
+            session.commit()
+            flash(f'You have joined the course {course_code}.')
+    return redirect(url_for('index'))
 
 
 

--- a/src/authroutes.py
+++ b/src/authroutes.py
@@ -249,41 +249,6 @@ def login():
                     flash('Invalid username or password.')
                     return redirect(url_for('authroutes.login'))
 
-            elif user_type == 'course-student':
-                username = request.form.get('username')
-                course_id = request.form.get('course_id')
-
-                ## Ensure that course_id exists
-                course = session.query(Course).filter_by(name=course_id).first()
-                if course is None:
-                    flash('Could not find a course with ID ' + course_id)
-                    return redirect(url_for('authroutes.login'))
-
-                ## If this username belongs to a password-protected account, the
-                ## passwordless course-code path must not log in as them (that
-                ## would bypass their password). Send them to the Student account
-                ## login instead.
-                existing = session.query(CourseStudent).filter_by(username=username).first()
-                if existing is not None and existing.password_hash:
-                    flash('That username has a password. Please use the "Student account" login instead.')
-                    return redirect(url_for('authroutes.login'))
-
-                ## TODO: User cannot be in more than one course. May have to change this later.
-                user = session.query(CourseStudent).filter_by(username=username, course_id=course_id).first()
-                canLogin = user is not None
-                ## If user did not already exist, create a new (passwordless) student enrolled in the course
-                if user is None:
-                    user = CourseStudent(username=username, course_id=course_id)
-                    try:
-                        session.add(user)
-                        session.commit()
-                        canLogin = user is not None
-                    except Exception as e:
-                        flash('User {username} already exists.'.format(username=username))
-                        session.rollback()
-                        canLogin = False
-
-
             elif user_type == 'anonymous-student':
                 ## This should really never happen, but just in case
                 tries_remaining = 10
@@ -310,10 +275,14 @@ def login():
                 flash('Login failed. Please try again.')
                 return redirect(url_for('authroutes.login'))
     elif request.method == 'GET':
-        user_type = request.args.get('user_type', '')
+        # A course code no longer logs a student in on its own — it enrolls a
+        # new, password-protected account. Old course links (?course_id=...)
+        # therefore lead to sign-up, where the code is applied.
         course_id = request.args.get('course_id', '')
+        if course_id:
+            return redirect(url_for('authroutes.signup_student', course_id=course_id))
         next_page = _get_safe_next_param()
-        return render_template('auth/login.html', user_type=user_type, course_id=course_id, next_page=next_page)
+        return render_template('auth/login.html', next_page=next_page)
     else:
         return "Invalid request method.", 400
 
@@ -364,16 +333,16 @@ def signup_student():
 
             if not username or not password:
                 flash('Username and password are required.')
-                return render_template('auth/signup_student.html')
+                return render_template('auth/signup_student.html', course_id=course_code)
 
             if password != confirm_password:
                 flash('Passwords do not match. Please try again.')
-                return render_template('auth/signup_student.html')
+                return render_template('auth/signup_student.html', course_id=course_code)
 
             existing_user = session.query(User).filter_by(username=username).first()
             if existing_user:
                 flash(f'Username {username} is already taken. Please choose another one.')
-                return render_template('auth/signup_student.html')
+                return render_template('auth/signup_student.html', course_id=course_code)
 
             ## Optional enrollment: only accept a course code that exists.
             course_id = None
@@ -381,7 +350,7 @@ def signup_student():
                 course = session.query(Course).filter_by(name=course_code).first()
                 if course is None:
                     flash('Could not find a course with ID ' + course_code)
-                    return render_template('auth/signup_student.html')
+                    return render_template('auth/signup_student.html', course_id=course_code)
                 course_id = course_code
 
             user = CourseStudent(username=username, course_id=course_id)
@@ -390,7 +359,8 @@ def signup_student():
             session.commit()
             login_user(user)
             return redirect(url_for('index'))
-    return render_template('auth/signup_student.html')
+    # GET: a course code may be supplied by a QR / shared link to pre-fill the form.
+    return render_template('auth/signup_student.html', course_id=request.args.get('course_id', ''))
 
 
 @authroutes.route('/join-course', methods=['POST'])
@@ -442,9 +412,9 @@ def register_exercise():
             session.add(course)
             session.commit()
 
-            login_link = url_for('authroutes.login', user_type='course-student', course_id=course.name, _external=True)
+            signup_link = url_for('authroutes.signup_student', course_id=course.name, _external=True)
 
-            flash(f'Course <code>{coursename}</code> registered successfully. <br><br> You can share it with students via the course code <code>{course.name}</code> or the link <code>{login_link}</code> <br><br>This link, along with a scannable QR code, will also be available in your instructor dashboard.')
+            flash(f'Course <code>{coursename}</code> registered successfully. <br><br> Students join by creating an account at the sign-up link <code>{signup_link}</code> (the course code <code>{course.name}</code> is filled in for them) or with the course code directly. <br><br>This link, along with a scannable QR code, will also be available in your instructor dashboard.')
             return redirect(url_for('authroutes.register_exercise'))
     return render_template('instructorhome.html')
 
@@ -452,9 +422,10 @@ def register_exercise():
 @authroutes.route('/course/<course_name>/qr.svg')
 @login_required_as_courseinstructor
 def course_login_qr(course_name):
-    """Serve a QR code (SVG) encoding the student login link for a course.
+    """Serve a QR code (SVG) encoding the student sign-up link for a course.
     Restricted to the instructor who owns the course. Students scan it to open
-    the pre-filled course sign-up/login page."""
+    the sign-up page with the course code pre-filled, and create a
+    password-protected account enrolled in the course."""
     import io
     import segno
 
@@ -463,13 +434,12 @@ def course_login_qr(course_name):
         if course is None or course.owner != current_user.username:
             abort(404)
 
-    login_link = url_for(
-        'authroutes.login',
-        user_type='course-student',
+    signup_link = url_for(
+        'authroutes.signup_student',
         course_id=course_name,
         _external=True,
     )
-    qr = segno.make(login_link, error='m')
+    qr = segno.make(signup_link, error='m')
     buf = io.BytesIO()
     qr.save(buf, kind='svg', scale=6, border=2)
     return Response(buf.getvalue(), mimetype='image/svg+xml')

--- a/src/templates/auth/login.html
+++ b/src/templates/auth/login.html
@@ -61,33 +61,17 @@
 
 
 
-        <p class="lead toggle-arrow {% if course_id %} {% else %}collapsed{% endif %}" data-toggle="collapse" href="#collapseCourseCode" role="button"
-            aria-expanded="{{ 'true' if course_id else 'false' }}" aria-controls="collapseCourseCode">
+        <p class="lead toggle-arrow collapsed" data-toggle="collapse" href="#collapseCourseCode" role="button"
+            aria-expanded="false" aria-controls="collapseCourseCode">
             Have a course code?
         </p>
-        <div class="collapse{% if course_id %} show highlight-section{% endif %}" id="collapseCourseCode">
-            <form action="/login" method="POST">
-
-                <p class="text-muted"> If you are using this tutor as part of a course, you can login as a student using
-                    your instructor-provided username and course code. </p>
-                <input type="hidden" name="user_type" value="course-student">
-                <input type="hidden" name="next" value="{{ next_page }}">
-
-                <div class="form-group row">
-                    <label for="username-student" class="col-sm-2 col-form-label">Username:</label>
-                    <div class="col-sm-10">
-                        <input type="text" id="username-student" name="username" class="form-control" required>
-                    </div>
-                </div>
-                <div class="form-group row">
-                    <label for="course_id" class="col-sm-2 col-form-label">Course:</label>
-                    <div class="col-sm-10">
-                        <input type="text" id="course_id" name="course_id" class="form-control" required value="{{ course_id }}">
-                    </div>
-                </div>
-
-                <input type="submit" value="Login as a Student" class="btn btn-primary">
-            </form>
+        <div class="collapse" id="collapseCourseCode">
+            <p class="text-muted">
+                Joining a course? Create a student account and enter your instructor's course code
+                during sign-up. Your progress stays with your account &mdash; and only you, with your
+                password, can log in as you.
+            </p>
+            <a href="/signup-student" class="btn btn-primary">Create a student account</a>
         </div>
 
         <hr class="my-2">

--- a/src/templates/auth/login.html
+++ b/src/templates/auth/login.html
@@ -91,30 +91,30 @@
         </div>
 
         <hr class="my-2">
-        <p class="lead toggle-arrow collapsed" data-toggle="collapse" href="#collapseSelfStudy" role="button"
-            aria-expanded="false" aria-controls="collapseSelfStudy">
-            Personal study account
+        <p class="lead toggle-arrow collapsed" data-toggle="collapse" href="#collapseStudentAccount" role="button"
+            aria-expanded="false" aria-controls="collapseStudentAccount">
+            Student account
         </p>
-        <div class="collapse" id="collapseSelfStudy">
+        <div class="collapse" id="collapseStudentAccount">
             <form action="/login" method="POST">
                 <p class="text-muted">
-                    Studying on your own, without a course? Log in to a personal account to keep your
-                    progress across devices and browsers.
-                    Don't have one yet? <a href="/signup-student" class="btn btn-outline-primary">Create a study account</a>
+                    A student account keeps your progress across devices and browsers &mdash; with or
+                    without a course. Log in with your username and password.
+                    Don't have one yet? <a href="/signup-student" class="btn btn-outline-primary">Create a student account</a>
                 </p>
-                <input type="hidden" name="user_type" value="self-study-student">
+                <input type="hidden" name="user_type" value="student-account">
                 <input type="hidden" name="next" value="{{ next_page }}">
 
                 <div class="form-group row">
-                    <label for="selfstudy-username" class="col-sm-2 col-form-label">Username:</label>
+                    <label for="studentacct-username" class="col-sm-2 col-form-label">Username:</label>
                     <div class="col-sm-10">
-                        <input type="text" id="selfstudy-username" name="username" class="form-control" required>
+                        <input type="text" id="studentacct-username" name="username" class="form-control" required>
                     </div>
                 </div>
                 <div class="form-group row">
-                    <label for="selfstudy-password" class="col-sm-2 col-form-label">Password:</label>
+                    <label for="studentacct-password" class="col-sm-2 col-form-label">Password:</label>
                     <div class="col-sm-10">
-                        <input type="password" id="selfstudy-password" name="password" class="form-control" required>
+                        <input type="password" id="studentacct-password" name="password" class="form-control" required>
                     </div>
                 </div>
 

--- a/src/templates/auth/login.html
+++ b/src/templates/auth/login.html
@@ -91,6 +91,38 @@
         </div>
 
         <hr class="my-2">
+        <p class="lead toggle-arrow collapsed" data-toggle="collapse" href="#collapseSelfStudy" role="button"
+            aria-expanded="false" aria-controls="collapseSelfStudy">
+            Personal study account
+        </p>
+        <div class="collapse" id="collapseSelfStudy">
+            <form action="/login" method="POST">
+                <p class="text-muted">
+                    Studying on your own, without a course? Log in to a personal account to keep your
+                    progress across devices and browsers.
+                    Don't have one yet? <a href="/signup-student" class="btn btn-outline-primary">Create a study account</a>
+                </p>
+                <input type="hidden" name="user_type" value="self-study-student">
+                <input type="hidden" name="next" value="{{ next_page }}">
+
+                <div class="form-group row">
+                    <label for="selfstudy-username" class="col-sm-2 col-form-label">Username:</label>
+                    <div class="col-sm-10">
+                        <input type="text" id="selfstudy-username" name="username" class="form-control" required>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label for="selfstudy-password" class="col-sm-2 col-form-label">Password:</label>
+                    <div class="col-sm-10">
+                        <input type="password" id="selfstudy-password" name="password" class="form-control" required>
+                    </div>
+                </div>
+
+                <input type="submit" value="Login" class="btn btn-primary">
+            </form>
+        </div>
+
+        <hr class="my-2">
         <p class="lead toggle-arrow collapsed" data-toggle="collapse" href="#collapseInstructorLogin" role="button"
             aria-expanded="false" aria-controls="collapseInstructorLogin">
             Instructor Login

--- a/src/templates/auth/signup_student.html
+++ b/src/templates/auth/signup_student.html
@@ -47,6 +47,7 @@
                     <div class="form-group">
                         <label for="course_id">Course code <span class="text-muted">(optional)</span>:</label>
                         <input type="text" id="course_id" name="course_id" class="form-control"
+                               value="{{ course_id or '' }}"
                                placeholder="Leave blank if you're not in a course">
                     </div>
 

--- a/src/templates/auth/signup_student.html
+++ b/src/templates/auth/signup_student.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+
+{% block title %}LTL Tutor: Create a study account{% endblock %}
+
+{% block navbar %}{% endblock %}
+
+{% block content %}
+        <div class="row justify-content-center">
+            <div class="col-md-6">
+                <h1 class="text-center mb-4">Create a study account</h1>
+
+                <div class="alert alert-secondary" role="alert">
+                    A personal study account lets you practice on your own — without a course —
+                    and keeps your progress across devices and browsers. Choose a username and
+                    password you'll remember; there is currently no way to recover a forgotten password.
+                </div>
+                {% with messages = get_flashed_messages() %}
+                {% if messages %}
+                    <div class="alert alert-primary alert-dismissible fade show" role="alert">
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">×</span>
+                        </button>
+                        {% for message in messages %}
+                            {{ message }}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+                {% endwith %}
+
+                <form action="/signup-student" method="POST" id="studentSignupForm">
+                    <div class="form-group">
+                        <label for="username">Username:</label>
+                        <input type="text" id="username" name="username" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="password">Password:</label>
+                        <input type="password" id="password" name="password" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="confirm_password">Confirm Password:</label>
+                        <input type="password" id="confirm_password" name="confirm_password" class="form-control" required>
+                    </div>
+
+                    <input type="submit" value="Create account" class="btn btn-primary">
+                </form>
+
+                <p class="text-center mt-3">
+                    Already have an account? <a href="/login" class="btn btn-outline-primary">Login here</a>
+                </p>
+            </div>
+        </div>
+{% endblock %}
+
+{% block scripts %}
+    <script>
+    document.getElementById('studentSignupForm').addEventListener('submit', function(e) {
+        const pw = document.getElementById('password').value;
+        const cpw = document.getElementById('confirm_password').value;
+        if (pw !== cpw) {
+            e.preventDefault();
+            alert('Passwords do not match!');
+        }
+    });
+    </script>
+{% endblock %}

--- a/src/templates/auth/signup_student.html
+++ b/src/templates/auth/signup_student.html
@@ -1,18 +1,19 @@
 {% extends 'base.html' %}
 
-{% block title %}LTL Tutor: Create a study account{% endblock %}
+{% block title %}LTL Tutor: Create a student account{% endblock %}
 
 {% block navbar %}{% endblock %}
 
 {% block content %}
         <div class="row justify-content-center">
             <div class="col-md-6">
-                <h1 class="text-center mb-4">Create a study account</h1>
+                <h1 class="text-center mb-4">Create a student account</h1>
 
                 <div class="alert alert-secondary" role="alert">
-                    A personal study account lets you practice on your own — without a course —
-                    and keeps your progress across devices and browsers. Choose a username and
-                    password you'll remember; there is currently no way to recover a forgotten password.
+                    A student account keeps your progress across devices and browsers. Choose a
+                    username and password you'll remember; there is currently no way to recover a
+                    forgotten password. If you're in a course you can add its course code now, or
+                    join a course later from your home page.
                 </div>
                 {% with messages = get_flashed_messages() %}
                 {% if messages %}
@@ -41,6 +42,12 @@
                     <div class="form-group">
                         <label for="confirm_password">Confirm Password:</label>
                         <input type="password" id="confirm_password" name="confirm_password" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="course_id">Course code <span class="text-muted">(optional)</span>:</label>
+                        <input type="text" id="course_id" name="course_id" class="form-control"
+                               placeholder="Leave blank if you're not in a course">
                     </div>
 
                     <input type="submit" value="Create account" class="btn btn-primary">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -9,6 +9,19 @@
     <!-- The number of misconceptions needed before review -->
     {% set threshold = 5 %}
 
+    {% with messages = get_flashed_messages() %}
+    {% if messages %}
+    <div class="alert alert-info alert-dismissible fade show mt-3" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        {% for message in messages %}
+            {{ message }}
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+
     <div class="d-flex justify-content-between align-items-center mt-3 mb-3 flex-wrap">
         <div class="d-flex align-items-center">
             {% if num_logs > 0 %}
@@ -21,6 +34,24 @@
             {% endif %}
         </div>
     </div>
+
+    <!-- Join a Course (persistent students not yet in a course) -->
+    {% if can_join_course %}
+    <div class="card border-info mb-4">
+        <div class="card-body">
+            <h6 class="mb-2">Join a course</h6>
+            <p class="text-muted mb-2">
+                Have a course code from your instructor? Enter it to see your course's assigned exercises.
+            </p>
+            <form action="{{ url_for('authroutes.join_course') }}" method="POST" class="form-inline">
+                <label class="sr-only" for="join-course-code">Course code</label>
+                <input type="text" id="join-course-code" name="course_id" class="form-control mr-2 mb-2"
+                       placeholder="Course code" required>
+                <button type="submit" class="btn btn-primary mb-2">Join course</button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
 
     <!-- Course Exercises Section -->
     {% if course_exercises and course_exercises|length > 0 %}

--- a/src/templates/instructorhome.html
+++ b/src/templates/instructorhome.html
@@ -72,6 +72,22 @@
                                 {% endif %}
                             </p>
 
+                            <div class="mt-2 mb-2">
+                                <p class="mb-1"><strong>Student sign-up QR code:</strong></p>
+                                <a href="{{ url_for('authroutes.course_login_qr', course_name=course.name) }}"
+                                   target="_blank" rel="noopener"
+                                   title="Open full size to project or print">
+                                    <img src="{{ url_for('authroutes.course_login_qr', course_name=course.name) }}"
+                                         alt="QR code linking to the student sign-up page for course {{ course.name }}"
+                                         width="140" height="140"
+                                         style="border:1px solid #dee2e6; background:#fff; padding:4px;">
+                                </a>
+                                <p class="text-muted small mb-0">
+                                    Students scan this to open the sign-up page for
+                                    <code>{{ course.name }}</code>. Click the code to enlarge it for projecting or printing.
+                                </p>
+                            </div>
+
                             <div>
                                 <h6>Top misconceptions</h6>
                                 {% if course.top_misconceptions %}

--- a/src/templates/instructorhome.html
+++ b/src/templates/instructorhome.html
@@ -57,8 +57,8 @@
                                 <span class="badge badge-info">{{ course.students|length }} student(s)</span>
                                 <a href="/view/responses/{{course.name}}" class="btn btn-primary btn-sm ml-2">View Logs</a>
                                 <button class="btn btn-secondary btn-sm ml-2 copy-login-link-btn"
-                                        data-login-link="{{ url_for('authroutes.login', user_type='course-student', course_id=course.name, _external=True) }}">
-                                    Copy Student Login Link
+                                        data-login-link="{{ url_for('authroutes.signup_student', course_id=course.name, _external=True) }}">
+                                    Copy Student Sign-up Link
                                 </button>
                             </div>
                         </div>
@@ -166,7 +166,7 @@
                 const link = btn.getAttribute('data-login-link');
                 navigator.clipboard.writeText(link).then(function() {
                     btn.textContent = 'Copied!';
-                    setTimeout(() => { btn.textContent = 'Copy Student Login Link'; }, 1500);
+                    setTimeout(() => { btn.textContent = 'Copy Student Sign-up Link'; }, 1500);
                 });
             });
         });


### PR DESCRIPTION
Improves onboarding/login: QR sign-up codes and persistent student accounts, plus a security fix that requires passwords for every account except Quick Start.

## Passwords for everyone except Quick Start (impersonation fix)

Previously a course student logged in with just **username + course code, no password**. Course codes are shared, low-entropy, and now literally printed on a projected QR — so any classmate could log in as another student, see their progress, and submit under their name (which also pollutes the instructor's per-student data). This removes that path:

- **Login is always username + password** for students; the passwordless course-code login is gone.
- The **course code becomes an enrollment input at sign-up**, not a login credential. Only **Quick Start** (anonymous, throwaway) stays passwordless.
- **No data deleted** — existing rows are untouched; the passwordless code path simply no longer exists.

## QR codes for course sign-up (Q3)

- New instructor-only route `GET /course/<name>/qr.svg` renders a QR (via `segno`, pure-Python) of the **sign-up page with the course code pre-filled** — scan → create your account for course X. Shown per course on the dashboard, ownership-gated (404 for non-owners / unknown courses), openable full-size to project or print.
- The dashboard "copy link" button and the register-course share link point to the same pre-filled sign-up URL; old `/login?course_id=` links redirect to sign-up.

## Persistent student accounts (Q1)

Modeled by giving the single `CourseStudent` an **optional password** alongside its **optional course** — one type now covers a persistent student and a persistent student who is also enrolled in a course.

- `password_hash` + `set_password`/`check_password` hoisted onto the base `User` (shared with instructors). **No DB migration** — the column already exists on `users`.
- New `/signup-student` (username + password + optional course code) and a "Student account" login section on the login page.
- `/join-course` lets a student enroll (from the home page) after signing up without a course.
- `index.html` now renders flashed messages (join success/errors were previously silent).

## Notes

- Adds `segno>=1.5` to `requirements.txt` (rebuild the image / reinstall requirements to pick it up).
- **No password recovery yet** — a forgotten password means a lost account (stated on the signup page). Natural next step: email or a no-PII recovery code.

## Testing

Drove the real routes through Flask's test client against a throwaway SQLite DB (SPOT stubbed out): the removed passwordless path (400 + no silent account creation), an explicit **impersonation attempt that is now blocked** (username + course code is no longer enough), password sign-up/login (+ wrong password), the QR now encoding the sign-up URL, `?course_id=` pre-fill, old-link redirect to sign-up, `/join-course` (success / invalid / instructor-forbidden), plus regressions for Quick Start, instructor login, and the QR route. Login, signup, and home templates were rendered to confirm the UI.
