### PR TITLE
Add deontic audit arm (abac theme): three-arm framing experiment

### DIFF
--- a/src/exercisebuilder.py
+++ b/src/exercisebuilder.py
@@ -607,7 +607,7 @@ class ExerciseBuilder:
     # spanning old and new responses will split the condition in two.
     THEME_TRANSLATION_MODES = {
         "lights": "contextualized",
-        "abac": "contextualized_deontic",
+        "abac": "contextualizeddeontic",
     }
 
     def build_english_to_ltl_question(self, answer, contextualized=False, theme_name=None):

--- a/src/exercisebuilder.py
+++ b/src/exercisebuilder.py
@@ -403,15 +403,22 @@ class ExerciseBuilder:
             if kind == self.TRACESATMC:
                 question = self.build_tracesat_mc_question(answer)
             elif kind == self.ENGLISHTOLTL:
-                # A/B test: 50/50 abstract vs. contextualized framing. The
-                # contextualized arm reuses the same formula with literals
-                # renamed onto the lights theme, so the two conditions differ
-                # only in framing, not in formula structure.
+                # Randomized framing experiment, one arm per question (1/3 each):
+                #   abstract — plain prose over bare literals (control)
+                #   lights   — same formula renamed onto the light panel
+                #              (concrete but descriptive content)
+                #   abac     — same formula renamed onto the document-access
+                #              audit theme and phrased as a policy to enforce
+                #              (concrete AND deontic — the Wason arm)
+                # Every arm poses the SAME formula modulo literal renaming, so
+                # conditions differ only in framing. Themed arms fall back to
+                # abstract if the formula cannot be themed.
                 question = None
-                if random.random() < 0.5:
-                    ctx_answer = self.gen_contextualized_answer(answer)
+                arm = random.choice(("abstract", "lights", "abac"))
+                if arm != "abstract":
+                    ctx_answer = self.gen_contextualized_answer(answer, theme_name=arm)
                     if ctx_answer is not None:
-                        question = self.build_english_to_ltl_question(ctx_answer, contextualized=True)
+                        question = self.build_english_to_ltl_question(ctx_answer, theme_name=arm)
                 if question is None:
                     question = self.build_english_to_ltl_question(answer)
             elif kind == self.TRACESATYN:
@@ -463,31 +470,35 @@ class ExerciseBuilder:
         return result
 
 
-    def gen_contextualized_answer(self, formula):
-        """Rename *formula*'s literals onto the lights theme.
+    def gen_contextualized_answer(self, formula, theme_name="lights"):
+        """Rename *formula*'s literals onto the given theme.
 
         Returns the renamed formula string, or None if it cannot be themed
-        (parse failure or more distinct literals than the theme has lights).
+        (parse failure or more distinct literals than the theme can name).
         """
         try:
             as_node = ltlnode.parse_ltl_string(formula)
         except Exception:
             return None
-        remapped = ltltoeng_contextualized.remap_to_theme(as_node)
+        theme = ltltoeng_contextualized.THEMES[theme_name]
+        remapped = ltltoeng_contextualized.remap_to_theme(as_node, theme)
         return str(remapped) if remapped is not None else None
 
 
-    def gen_nl_question_contextualized(self, formula):
-        """Generate a contextualized English question using the lights theme.
+    def gen_nl_question_contextualized(self, formula, theme_name="lights"):
+        """Generate a contextualized English question using the given theme.
 
         Expects the formula's literals to already match the theme (see
-        gen_contextualized_answer). Returns None if translation fails.
+        gen_contextualized_answer). Deontic themes get their stance-setting
+        preamble prepended. Returns None if translation fails.
         """
-        LIGHTS_THEME = ltltoeng_contextualized.THEMES["lights"]
+        theme = ltltoeng_contextualized.THEMES[theme_name]
         as_node = ltlnode.parse_ltl_string(formula)
-        result = ltltoeng_contextualized.translate(as_node, LIGHTS_THEME)
+        result = ltltoeng_contextualized.translate(as_node, theme)
         if not result or result.strip() == "":
             return None
+        if theme.preamble:
+            result = f"{theme.preamble}\n\n{result}"
         return result
 
 
@@ -591,15 +602,27 @@ class ExerciseBuilder:
 
         return final_options
 
-    def build_english_to_ltl_question(self, answer, contextualized=False):
+    # translation_mode value logged per themed arm. "contextualized" is the
+    # historical value for the lights arm — do not rename it, or analyses
+    # spanning old and new responses will split the condition in two.
+    THEME_TRANSLATION_MODES = {
+        "lights": "contextualized",
+        "abac": "contextualized_deontic",
+    }
+
+    def build_english_to_ltl_question(self, answer, contextualized=False, theme_name=None):
 
         options = self.get_options_with_misconceptions_as_formula(answer)
         if options is None:
             return None
 
-        if contextualized:
-            question = self.gen_nl_question_contextualized(answer)
-            translation_mode = "contextualized"
+        # Legacy callers use contextualized=True to mean the lights theme.
+        if theme_name is None and contextualized:
+            theme_name = "lights"
+
+        if theme_name is not None:
+            question = self.gen_nl_question_contextualized(answer, theme_name)
+            translation_mode = self.THEME_TRANSLATION_MODES[theme_name]
             # Fall back to abstract if contextualized translation fails
             if question is None or question == "":
                 question = self.gen_nl_question(answer)

--- a/src/ltltoeng_contextualized.py
+++ b/src/ltltoeng_contextualized.py
@@ -11,6 +11,18 @@ are chosen so that each literal is the color's first letter AND stays inside
 the tutor's exercise-literal pool, which deliberately avoids letters that look
 like LTL operators (r, g, f, u, x, w, m).
 
+A theme may also be *deontic*: the formula is phrased as a rule someone could
+violate ("the VPN must be connected") rather than a description, and a
+preamble puts the student in the role of policing it.  The Wason literature
+locates the facilitation effect in exactly this framing — violation-checkable
+rules — not in concrete content per se (Griggs & Cox 1982; Cheng & Holyoak
+1985; Cosmides 1989).  The built-in deontic theme, "abac", audits access to a
+confidential document.  Its four attributes are deliberately independent in
+the student's mental model: nothing physical forces any combination of them,
+so every state assignment is conceivable and only the policy under test rules
+combinations out.  Themes whose atoms are coupled by physics (doors, rooms,
+occupancy) would smuggle constraints into the trace semantics.
+
 Public API
 ----------
     translate(node, theme=None) -> str
@@ -53,10 +65,17 @@ class Theme:
         description: One-line description of the scenario.
         literals:    Maps literal names to (positive_phrase, negative_phrase).
                      e.g. {"b": ("the blue light is on", "the blue light is off")}
+        deontic:     Phrase the formula as an enforceable rule ("must") rather
+                     than a description.  Requires copular literal phrases
+                     ("the X is Y") so the modal transform stays grammatical.
+        preamble:    Stance-setting text shown before the sentence (only
+                     meaningful for deontic themes).  Empty = no preamble.
     """
     name: str
     description: str
     literals: Dict[str, tuple[str, str]]  # lit -> (positive, negative)
+    deontic: bool = False
+    preamble: str = ""
 
     def positive(self, lit: str) -> str:
         if lit in self.literals:
@@ -83,6 +102,24 @@ THEMES["lights"] = Theme(
         "a": ("the amber light is on",   "the amber light is off"),
         "p": ("the purple light is on",  "the purple light is off"),
         "c": ("the cyan light is on",    "the cyan light is off"),
+    },
+)
+
+# Deontic theme: an ABAC-style policy on one confidential document.  The four
+# attributes are independent — no combination is physically impossible, only
+# policy-forbidden — and each positive/negative pair is a natural antonym so
+# negated literals read cleanly.  First-letter convention and the operator-safe
+# letter pool (d, c, v, s) are preserved.
+THEMES["abac"] = Theme(
+    name="Document Access Audit",
+    description="Auditing access to a confidential document.",
+    deontic=True,
+    preamble="You are auditing access to a confidential document. Company policy:",
+    literals={
+        "d": ("the document is open",            "the document is closed"),
+        "c": ("the user's clearance is active",  "the user's clearance is revoked"),
+        "v": ("the VPN is connected",            "the VPN is disconnected"),
+        "s": ("the screen is shared",            "the screen is not shared"),
     },
 )
 
@@ -136,6 +173,44 @@ def _steps(n: int) -> str:
     if n == 1:
         return "the very next step"
     return f"{n} steps from now"
+
+
+def _lit_phrase(node: ltlnode.LTLNode, theme: Theme) -> Optional[str]:
+    """The state phrase for a literal or negated literal, else None."""
+    if isinstance(node, ltlnode.LiteralNode):
+        return theme.positive(node.value)
+    if isinstance(node, ltlnode.NotNode) and isinstance(node.operand, ltlnode.LiteralNode):
+        return theme.negative(node.operand.value)
+    return None
+
+
+def _modal(phrase: str, adverb: str = "") -> str:
+    """Rewrite a copular state phrase as an obligation.
+
+    "the VPN is connected"      -> "the VPN must be connected"
+    "the screen is not shared"  -> "the screen must not be shared"
+    With an adverb it slots in after "must":
+    _modal("the VPN is connected", "eventually")
+                                -> "the VPN must eventually be connected"
+    Non-copular phrases fall back to a generic "it must be the case that"
+    wrapper, so the transform is safe on any recursive translation.
+    """
+    must = f"must {adverb}".strip()
+    if " is not " in phrase:
+        return phrase.replace(" is not ", f" {must} not be ", 1)
+    if " is " in phrase:
+        return phrase.replace(" is ", f" {must} be ", 1)
+    if " are " in phrase:
+        return phrase.replace(" are ", f" {must} be ", 1)
+    return f"it {must} be the case that {phrase}"
+
+
+def _obligation(node: ltlnode.LTLNode, theme: Theme, adverb: str = "") -> str:
+    """Deontic rendering of a rule's consequent/scope."""
+    phrase = _lit_phrase(node, theme)
+    if phrase is not None:
+        return _modal(phrase, adverb)
+    return _modal(_t(node, theme), adverb)
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +276,8 @@ def _t_not(node: ltlnode.NotNode, theme: Theme) -> str:
 
     # !(F p) -> never
     if isinstance(inner, ltlnode.FinallyNode) and isinstance(inner.operand, ltlnode.LiteralNode):
+        if theme.deontic:
+            return _modal(theme.positive(inner.operand.value), "never")
         return f"it is never the case that {theme.positive(inner.operand.value)}"
 
     # !!p
@@ -209,6 +286,8 @@ def _t_not(node: ltlnode.NotNode, theme: Theme) -> str:
 
     # !(p & q) -> not both
     if isinstance(inner, ltlnode.AndNode):
+        if theme.deontic:
+            return f"it must not be the case that both {_t(inner.left, theme)} and {_t(inner.right, theme)}"
         return f"it is not the case that both {_t(inner.left, theme)} and {_t(inner.right, theme)}"
 
     # !(p | q) -> neither/nor
@@ -254,17 +333,22 @@ def _t_or(node: ltlnode.OrNode, theme: Theme) -> str:
 # --- IMPLIES --------------------------------------------------------------
 
 def _t_implies(node: ltlnode.ImpliesNode, theme: Theme) -> str:
+    # Deontic themes place the obligation on the consequent; the trigger
+    # stays indicative ("if the document is open, the VPN must be connected").
+    if theme.deontic:
+        r = _obligation(node.right, theme)
+    else:
+        r = _t(node.right, theme)
+
     # (p & q) -> r
     if isinstance(node.left, ltlnode.AndNode):
-        r = _t(node.right, theme)
         return f"if both {_t(node.left.left, theme)} and {_t(node.left.right, theme)}, then {r}"
 
     # (p | q) -> r
     if isinstance(node.left, ltlnode.OrNode):
-        r = _t(node.right, theme)
         return f"if either {_t(node.left.left, theme)} or {_t(node.left.right, theme)}, then {r}"
 
-    return f"if {_t(node.left, theme)}, then {_t(node.right, theme)}"
+    return f"if {_t(node.left, theme)}, then {r}"
 
 
 # --- EQUIVALENCE ----------------------------------------------------------
@@ -282,7 +366,15 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
     if isinstance(inner, ltlnode.NotNode):
         negated = inner.operand
         if isinstance(negated, ltlnode.LiteralNode):
+            if theme.deontic:
+                return _modal(theme.positive(negated.value), "never")
             return f"it is never the case that {theme.positive(negated.value)}"
+        # G(!(p & q)) -> "P must never hold while Q holds"
+        if theme.deontic and isinstance(negated, ltlnode.AndNode):
+            lp = _lit_phrase(negated.left, theme)
+            rp = _lit_phrase(negated.right, theme)
+            if lp is not None and rp is not None:
+                return f"{_modal(lp, 'never')} while {rp}"
         return f"at no point may it be the case that {_t(negated, theme)}"
 
     # G(p -> ...) patterns
@@ -294,6 +386,8 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
         if isinstance(right, (ltlnode.NextNode, ltlnode.GloballyNode)):
             if _same_literal(left, right.operand):
                 lit = left.value
+                if theme.deontic:
+                    return f"once {theme.positive(lit)}, it must stay that way forever"
                 return f"once {theme.positive(lit)}, it stays that way forever"
 
         # G(p -> F q) — response
@@ -301,6 +395,13 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
             if isinstance(left, ltlnode.UntilNode):
                 p = _t(left.left, theme)
                 q = _t(left.right, theme)
+                if theme.deontic:
+                    r = _obligation(right.operand, theme, "eventually")
+                    return _join(
+                        f"suppose {p} continues until {q}",
+                        f"then {r}",
+                        "this rule applies every time",
+                    )
                 r = _t(right.operand, theme)
                 return _join(
                     f"suppose {p} continues until {q}",
@@ -308,18 +409,25 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
                     "this rule applies every time",
                 )
             trigger = _t(left, theme)
+            if theme.deontic:
+                return f"whenever {trigger}, {_obligation(right.operand, theme, 'eventually')}"
             response = _t(right.operand, theme)
             return f"whenever {trigger}, then eventually {response}"
 
         # G(p -> X(F q)) — bounded response
         if isinstance(right, ltlnode.NextNode) and isinstance(right.operand, ltlnode.FinallyNode):
             trigger = _t(left, theme)
+            if theme.deontic:
+                response = _obligation(right.operand.operand, theme, "eventually")
+                return f"whenever {trigger}, starting from the very next step, {response}"
             response = _t(right.operand.operand, theme)
             return f"whenever {trigger}, starting from the very next step, eventually {response}"
 
         # G(p -> X q) — immediate response
         if isinstance(right, ltlnode.NextNode):
             trigger = _t(left, theme)
+            if theme.deontic:
+                return f"whenever {trigger}, {_obligation(right.operand, theme)} in the very next step"
             response = _t(right.operand, theme)
             return f"whenever {trigger}, then {response} in the very next step"
 
@@ -341,6 +449,8 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
 
         # G(p -> q) — generic
         trigger = _t(left, theme)
+        if theme.deontic:
+            return f"whenever {trigger}, {_obligation(right, theme)}"
         consequence = _t(right, theme)
         return f"whenever {trigger}, it must be the case that {consequence}"
 
@@ -358,13 +468,21 @@ def _t_globally(node: ltlnode.GloballyNode, theme: Theme) -> str:
 
     # G(p & q) / G(p | q)
     if isinstance(inner, ltlnode.AndNode):
+        if theme.deontic:
+            return f"at every moment, it must be the case that {_t(inner.left, theme)} and {_t(inner.right, theme)}"
         return f"at every moment, {_t(inner.left, theme)} and {_t(inner.right, theme)}"
     if isinstance(inner, ltlnode.OrNode):
+        if theme.deontic:
+            return f"at every moment, it must be the case that either {_t(inner.left, theme)} or {_t(inner.right, theme)}"
         return f"at every moment, either {_t(inner.left, theme)} or {_t(inner.right, theme)}"
 
     # G(literal)
     if isinstance(inner, ltlnode.LiteralNode):
+        if theme.deontic:
+            return _modal(theme.positive(inner.value), "always")
         return f"{theme.positive(inner.value)} at all times"
+    if theme.deontic:
+        return _modal(_t(inner, theme), "always")
     return f"at all times, {_t(inner, theme)}"
 
 
@@ -384,6 +502,12 @@ def _t_finally(node: ltlnode.FinallyNode, theme: Theme) -> str:
         # F(G(p -> F q))
         if isinstance(gi, ltlnode.ImpliesNode) and isinstance(gi.right, ltlnode.FinallyNode):
             trigger = _t(gi.left, theme)
+            if theme.deontic:
+                response = _obligation(gi.right.operand, theme, "eventually")
+                return _join(
+                    "eventually, the system stabilizes",
+                    f"from that point on, whenever {trigger}, {response}",
+                )
             response = _t(gi.right.operand, theme)
             return _join(
                 "eventually, the system stabilizes",
@@ -417,6 +541,8 @@ def _t_finally(node: ltlnode.FinallyNode, theme: Theme) -> str:
         result = _t(inner.right.operand, theme)
         return f"eventually, once {trigger}, then {result} forever after"
 
+    if theme.deontic:
+        return _obligation(inner, theme, "eventually")
     return f"eventually, {_t(inner, theme)}"
 
 
@@ -433,6 +559,11 @@ def _t_next(node: ltlnode.NextNode, theme: Theme) -> str:
     if steps == 1 and isinstance(core, ltlnode.FinallyNode):
         target = _t(core.operand, theme)
         return f"starting from the next step, {target} must eventually happen"
+
+    if theme.deontic:
+        phrase = _lit_phrase(core, theme)
+        if phrase is not None:
+            return f"{_modal(phrase)} in {_steps(steps)}"
 
     target = _t(core, theme)
     return f"in {_steps(steps)}, {target}"
@@ -464,6 +595,11 @@ def _t_until(node: ltlnode.UntilNode, theme: Theme) -> str:
 
     l = _t(l_node, theme)
     r = _t(r_node, theme)
+    if theme.deontic:
+        # "the document is closed" -> "the document must remain closed"
+        lp = _lit_phrase(l_node, theme)
+        if lp is not None and " is not " not in lp and " is " in lp:
+            return f"{lp.replace(' is ', ' must remain ', 1)} until {r}"
     return f"it must remain the case that {l} until {r}"
 
 

--- a/test/test_ab_contextualized.py
+++ b/test/test_ab_contextualized.py
@@ -95,7 +95,7 @@ class TestDeonticArm(unittest.TestCase):
             "G(z -> F k)", theme_name="abac")
         q = self.builder.build_english_to_ltl_question(themed, theme_name="abac")
         self.assertIsNotNone(q)
-        self.assertEqual(q["translation_mode"], "contextualized_deontic")
+        self.assertEqual(q["translation_mode"], "contextualizeddeontic")
 
     def test_deontic_question_has_preamble_and_obligation(self):
         themed = self.builder.gen_contextualized_answer(

--- a/test/test_ab_contextualized.py
+++ b/test/test_ab_contextualized.py
@@ -77,5 +77,49 @@ class TestTranslationModeLogging(unittest.TestCase):
             self.assertNotIn(f"'{lit}'", q["question"])
 
 
+class TestDeonticArm(unittest.TestCase):
+    """The abac (deontic audit) arm: same formula, policy framing, own mode."""
+
+    def setUp(self):
+        self.builder = StubBuilder()
+
+    def test_remaps_onto_abac_literals(self):
+        result = self.builder.gen_contextualized_answer(
+            "G(z -> F k)", theme_name="abac")
+        self.assertIsNotNone(result)
+        lits = ctx.collect_literals(parse_ltl_string(result))
+        self.assertTrue(lits.issubset(set(ctx.THEMES["abac"].literals)))
+
+    def test_deontic_question_marks_mode(self):
+        themed = self.builder.gen_contextualized_answer(
+            "G(z -> F k)", theme_name="abac")
+        q = self.builder.build_english_to_ltl_question(themed, theme_name="abac")
+        self.assertIsNotNone(q)
+        self.assertEqual(q["translation_mode"], "contextualized_deontic")
+
+    def test_deontic_question_has_preamble_and_obligation(self):
+        themed = self.builder.gen_contextualized_answer(
+            "G(z -> F k)", theme_name="abac")
+        q = self.builder.build_english_to_ltl_question(themed, theme_name="abac")
+        self.assertTrue(q["question"].startswith(ctx.THEMES["abac"].preamble))
+        self.assertIn("must", q["question"])
+
+    def test_deontic_question_has_no_quoted_literals(self):
+        themed = self.builder.gen_contextualized_answer(
+            "G(z -> (k U j))", theme_name="abac")
+        q = self.builder.build_english_to_ltl_question(themed, theme_name="abac")
+        for lit in ctx.THEMES["abac"].literals:
+            self.assertNotIn(f"'{lit}'", q["question"])
+
+    def test_lights_arm_has_no_preamble(self):
+        """Only the deontic arm carries a stance-setting preamble; the lights
+        arm must keep producing exactly what it produced before the third arm
+        existed, so historical responses stay comparable."""
+        themed = self.builder.gen_contextualized_answer("G(z -> F k)")
+        q = self.builder.build_english_to_ltl_question(themed, contextualized=True)
+        self.assertNotIn("\n", q["question"])
+        self.assertEqual(q["translation_mode"], "contextualized")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_contextualized_deontic.py
+++ b/test/test_contextualized_deontic.py
@@ -1,0 +1,198 @@
+"""Test the deontic (policy/audit) contextualized translator arm.
+
+The abac theme phrases each formula as a rule the student polices. Per the
+Wason selection task literature, facilitation comes from violation-checkable
+deontic rules, not from concrete content alone — so this arm differs from
+the lights arm in modality and stance, while posing the same formula.
+
+Run with:
+    python -m pytest test/test_contextualized_deontic.py -v -s
+"""
+
+import unittest
+import sys
+import os
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+from unittest.mock import MagicMock
+sys.modules['spot'] = MagicMock()
+
+from ltlnode import parse_ltl_string
+import ltltoeng_prose as prose
+import ltltoeng_contextualized as ctx
+
+
+class TestModalTransform(unittest.TestCase):
+    """_modal rewrites copular state phrases into obligations."""
+
+    def test_positive_copula(self):
+        self.assertEqual(ctx._modal("the VPN is connected"),
+                         "the VPN must be connected")
+
+    def test_negated_copula(self):
+        self.assertEqual(ctx._modal("the screen is not shared"),
+                         "the screen must not be shared")
+
+    def test_adverb_slots_after_must(self):
+        self.assertEqual(ctx._modal("the VPN is connected", "eventually"),
+                         "the VPN must eventually be connected")
+
+    def test_adverb_with_negation(self):
+        self.assertEqual(ctx._modal("the screen is not shared", "eventually"),
+                         "the screen must eventually not be shared")
+
+    def test_never(self):
+        self.assertEqual(ctx._modal("the document is open", "never"),
+                         "the document must never be open")
+
+    def test_non_copular_fallback(self):
+        self.assertEqual(ctx._modal("both conditions hold"),
+                         "it must be the case that both conditions hold")
+
+
+class TestAbacTheme(unittest.TestCase):
+    """Exact-sentence checks for the flagship policy skeletons."""
+
+    def setUp(self):
+        random.seed(42)
+        self.theme = ctx.THEMES["abac"]
+
+    def _tr(self, formula):
+        return ctx.translate(parse_ltl_string(formula), self.theme)
+
+    def test_invariant_implication(self):
+        self.assertEqual(self._tr("G(d -> v)"),
+            "Whenever the document is open, the VPN must be connected.")
+
+    def test_response(self):
+        self.assertEqual(self._tr("G(d -> F v)"),
+            "Whenever the document is open, the VPN must eventually be connected.")
+
+    def test_mutual_exclusion(self):
+        self.assertEqual(self._tr("G !(d & s)"),
+            "The document must never be open while the screen is shared.")
+
+    def test_never(self):
+        self.assertEqual(self._tr("G !d"),
+            "The document must never be open.")
+
+    def test_impossibility(self):
+        self.assertEqual(self._tr("!(F d)"),
+            "The document must never be open.")
+
+    def test_always(self):
+        self.assertEqual(self._tr("G v"),
+            "The VPN must always be connected.")
+
+    def test_liveness(self):
+        self.assertEqual(self._tr("F v"),
+            "The VPN must eventually be connected.")
+
+    def test_until_with_negated_left(self):
+        self.assertEqual(self._tr("(!d) U c"),
+            "The document must remain closed until the user's clearance is active.")
+
+    def test_negated_consequent_uses_antonym(self):
+        self.assertEqual(self._tr("G(s -> !d)"),
+            "Whenever the screen is shared, the document must be closed.")
+
+    def test_negated_consequent_without_antonym(self):
+        self.assertEqual(self._tr("G(d -> !s)"),
+            "Whenever the document is open, the screen must not be shared.")
+
+    def test_immediate_response(self):
+        self.assertEqual(self._tr("G(d -> X v)"),
+            "Whenever the document is open, the VPN must be connected in the very next step.")
+
+    def test_trigger_stays_indicative(self):
+        """Obligation lands on the consequent only — never on the trigger."""
+        out = self._tr("G(d -> F v)")
+        self.assertTrue(out.startswith("Whenever the document is open,"))
+        self.assertNotIn("document must", out)
+
+    def test_persistence(self):
+        self.assertEqual(self._tr("G(d -> X d)"),
+            "Once the document is open, it must stay that way forever.")
+
+    def test_eventual_stable_response(self):
+        self.assertEqual(self._tr("F(G(d -> F v))"),
+            "Eventually, the system stabilizes. "
+            "From that point on, whenever the document is open, "
+            "the VPN must eventually be connected.")
+
+    def test_not_both(self):
+        self.assertEqual(self._tr("!(d & s)"),
+            "It must not be the case that both the document is open "
+            "and the screen is shared.")
+
+
+class TestLightsUnchanged(unittest.TestCase):
+    """Deontic support must not alter the descriptive lights arm: historical
+    responses were collected under this exact wording."""
+
+    def _tr(self, formula):
+        return ctx.translate(parse_ltl_string(formula), ctx.THEMES["lights"])
+
+    def test_response_unchanged(self):
+        self.assertEqual(self._tr("G(b -> F a)"),
+            "Whenever the blue light is on, then eventually the amber light is on.")
+
+    def test_never_unchanged(self):
+        self.assertEqual(self._tr("G !b"),
+            "It is never the case that the blue light is on.")
+
+    def test_until_unchanged(self):
+        self.assertEqual(self._tr("(!b) U a"),
+            "It must remain the case that the blue light is off until the amber light is on.")
+
+
+FORMULAS = [
+    ("G b",                   "Invariant"),
+    ("F b",                   "Liveness"),
+    ("G !b",                  "Safety / never"),
+    ("G (b -> F a)",          "Response"),
+    ("G (b -> X a)",          "Immediate response"),
+    ("G(b -> (F a & F p))",   "Chain response"),
+    ("G(b -> (a U p))",       "Chain precedence"),
+    ("F (G b)",               "Persistence"),
+    ("G (F b)",               "Recurrence"),
+    ("(G b) U (F a)",         "Obligation until release"),
+    ("G(b -> X b)",           "Once true, stays true"),
+    ("!(F b)",                "Impossibility"),
+    ("b -> a",                "Simple implication"),
+    ("G(b -> X(F a))",        "Bounded response"),
+    ("F(G(b -> F a))",        "Eventual stable response"),
+    ("G((b U a) -> F p)",     "Until-triggered response"),
+    ("!(b & a)",              "Mutual exclusion"),
+    ("G !(b & a)",            "Mutual exclusion, always"),
+]
+
+
+class TestPrintThreeArms(unittest.TestCase):
+    """Print all three experimental arms side by side for eyeballing."""
+
+    def test_print_three_arms(self):
+        print("\n" + "=" * 110)
+        print("THREE-ARM COMPARISON: abstract / lights (descriptive) / abac (deontic)")
+        print("=" * 110)
+
+        for formula_str, desc in FORMULAS:
+            random.seed(42)
+            abstract = prose.translate(parse_ltl_string(formula_str))
+            lights = ctx.translate(parse_ltl_string(formula_str), ctx.THEMES["lights"])
+            abac_node = ctx.remap_to_theme(parse_ltl_string(formula_str), ctx.THEMES["abac"])
+            abac = ctx.translate(abac_node, ctx.THEMES["abac"]) if abac_node else "(cannot theme)"
+
+            print(f"\n{'─' * 110}")
+            print(f"  {formula_str:30s}  ({desc})")
+            print(f"{'─' * 110}")
+            print(f"  Abstract:  {abstract}")
+            print(f"  Lights:    {lights}")
+            print(f"  Audit:     {abac}")
+
+        print("\n" + "=" * 110)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The Wason selection task literature locates the facilitation effect in **deontic, violation-checkable rules** (Griggs & Cox 1982; Cheng & Holyoak 1985; Cosmides 1989) — not in concrete content alone, which repeatedly failed to replicate (and mere problem-context showed ~no effect in CS1, Bouvier et al. 2016). The lights theme is concrete but *descriptive*, so a null result on abstract-vs-lights alone would be uninterpretable: consistent with both "contextualization doesn't help LTL" and "we picked the known-inert kind of context."

This PR adds the deontic arm and turns the 50/50 A/B into a three-arm experiment (1/3 each):

| arm | framing | `translation_mode` |
|---|---|---|
| abstract | plain prose over bare literals | `abstract` |
| lights | concrete, **descriptive** — wording untouched | `contextualized` (historical value) |
| abac | concrete, **deontic**: document-access audit | `contextualizeddeontic` |

Predicted pattern per the literature: abstract ≈ lights < abac. Finding lights ≈ abac > abstract instead would also be informative (content, not deontic stance, drives any effect in this domain).

## The abac theme

Audits access to one confidential document: `d` document open/closed, `c` clearance active/revoked, `v` VPN connected/disconnected, `s` screen shared/not shared. Design constraints:

- **Atom independence:** attributes are coupled only by the policy under test, never by physics — every state assignment stays conceivable, so no mental-model constraints leak into trace semantics (physical scenarios like badge/door/room fail this).
- Natural antonym pairs, first-letter convention, operator-safe letter pool — all preserved.
- Same-formula-modulo-renaming invariant unchanged: all three arms pose the identical formula.

## Deontic rendering

`Theme` gains `deontic` and `preamble` fields. Deontic themes modalize **consequents only** via a copular transform ("is connected" → "must be connected"; adverbs slot after "must"); triggers stay indicative; non-copular consequents fall back to "it must be the case that…". An auditor-stance preamble is prepended:

> You are auditing access to a confidential document. Company policy:
>
> Whenever the document is open, the VPN must eventually be connected.

Sample outputs: `G !(d & s)` → "The document must never be open while the screen is shared." · `(!d) U c` → "The document must remain closed until the user's clearance is active." · `G(d -> X d)` → "Once the document is open, it must stay that way forever."

## Test plan

- New `test/test_contextualizeddeontic.py`: modal-transform unit tests, exact-sentence checks for the flagship policy skeletons, **lights-unchanged regression tests** (historical responses must stay comparable), and a three-arm print comparison (`pytest test/test_contextualizeddeontic.py::TestPrintThreeArms -s`).
- `test/test_ab_contextualized.py`: deontic arm mode value, preamble presence, no-literal-leak, legacy `contextualized=True` still means lights, lights arm carries no preamble.
- Full suite: 205 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
